### PR TITLE
Resolve issue of not working edit graph. 

### DIFF
--- a/editgraph
+++ b/editgraph
@@ -1,14 +1,9 @@
 #!/bin/bash
-which open
-if [ $? == 0 ] 
-then
-   open https://controlcore-project.github.io/DHGWorkflow/
-else
-   which xdg-open
-   if [ $? == 0 ] 
-   then
-      xdg-open https://controlcore-project.github.io/DHGWorkflow/
-   else
-      echo "unable to open browser for DHGWorkflow"
-   fi
+
+if [[ "$OSTYPE" =~ ^darwin ]]; then
+    open -a 'Google Chrome' https://controlcore-project.github.io/concore-editor/
+fi
+
+if [[ "$OSTYPE" =~ ^linux ]]; then
+    xdg-open https://controlcore-project.github.io/concore-editor/
 fi


### PR DESCRIPTION
The cause of issue#25 is in the "which open" command. As per my knowledge and research, there is no "open" command in Linux; instead, Linux uses xdg-open. But in my Linux OS, the command "which open" returns 0 as it gets some path( see attached image).   

![Screenshot from 2023-01-07 17-04-01](https://user-images.githubusercontent.com/36565630/211148531-8b1a1398-6d66-4bfc-b56c-71ffa8dfbc3c.png)

And "open -a https://controlcore-project.github.io/concore-editor/" and "open https://controlcore-project.github.io/concore-editor/" commands are not working in Linux (see attached image).

![Screenshot from 2023-01-07 18-08-15](https://user-images.githubusercontent.com/36565630/211151172-88511527-20ed-4040-bdb0-dbdaa5e55a56.png)

So, in my implementation, I put OS checks. I think it is a better way than the "which" command.