### PR TITLE
Wrong ports in code

### DIFF
--- a/fri/server/main.py
+++ b/fri/server/main.py
@@ -193,4 +193,4 @@ def openJupyter():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0")
+    app.run(host="0.0.0.0",port=8080)


### PR DESCRIPTION
Now docker container is running fine but ports are not mapped correctly ,

As default PORT of FLASK app is 5000 which should be changed to 8080 , because in Dockerfile it is 8080  here:- https://github.com/ControlCore-Project/concore/blob/main/fri/Dockerfile#L9

So the solution is We can change at either place

I am correcting the dockerfiles and debugging it , so that new comers can easily run it using container