### PR TITLE
Directory name added in destroy api call 

### DIFF
--- a/fri/server/main.py
+++ b/fri/server/main.py
@@ -191,9 +191,9 @@ def download(dir):
 def destroy(dir):
     dir = secure_filename(dir)
     if(platform.uname()[0]=='Windows'):
-        proc=call(["destroy"],shell=True, cwd=concore_path)
+        proc=call(["destroy", dir],shell=True, cwd=concore_path)
     else:
-        proc = call(["./destroy"], cwd=concore_path)
+        proc = call(["./destroy", dir], cwd=concore_path)
     if(proc == 0):
         resp = jsonify({'message': 'Successfuly deleted Dirctory'})
         resp.status_code = 201


### PR DESCRIPTION
@pradeeban 
In main.py directory name to be destroyed was not mentioned in main.py. therefore it was not destroying the directory and only showing success message.
I think while attempting one of the issues, I misplaced it and forgot to add it again.
Sorry for that.