### PR TITLE
Options button features in API updated

### DIFF
--- a/fri/server/main.py
+++ b/fri/server/main.py
@@ -65,7 +65,10 @@ def upload(dir):
 # to download /build/<dir>?fetch=<graphml>. For example, /build/test?fetch=sample1&apikey=xyz
 @app.route('/build/<dir>', methods=['POST'])
 def build(dir):
-    graphml_file = request.args.get('fetch')  
+    graphml_file = request.args.get('fetch')
+    params = request.args.get('params')
+    docker = request.args.get('docker')
+    maxtime = request.args.get('maxtime')
     apikey = request.args.get('apikey') 
     out_dir = request.args.get('outdir')
     if(apikey == None):
@@ -80,14 +83,26 @@ def build(dir):
     if not os.path.exists(dir_path):
         if(platform.uname()[0]=='Windows'):
             if(out_dir == None or out_dir == ""):
-                proc= call(["makestudy", makestudy_dir], shell=True, cwd=concore_path)
+                if(docker == 'true'):
+                    proc= call(["makedocker", makestudy_dir], shell=True, cwd=concore_path)
+                else:
+                    proc= call(["makestudy", makestudy_dir], shell=True, cwd=concore_path)
             else:
-                proc= call(["makestudy", makestudy_dir, out_dir], shell=True, cwd=concore_path)
+                if(docker == 'true'):
+                    proc= call(["makedocker", makestudy_dir, out_dir], shell=True, cwd=concore_path)
+                else:
+                    proc= call(["makestudy", makestudy_dir, out_dir], shell=True, cwd=concore_path)
         else:
             if(out_dir == None or out_dir == ""):
-                proc= call(["./makestudy", makestudy_dir], cwd=concore_path)
+                if(docker == 'true'):
+                    proc= call(["./makedocker", makestudy_dir], cwd=concore_path)
+                else:
+                    proc= call(["./makestudy", makestudy_dir], cwd=concore_path)
             else:
-                proc= call(["./makestudy", makestudy_dir, out_dir], cwd=concore_path)
+                if(docker == 'true'):
+                    proc= call(["./makedocker", makestudy_dir, out_dir], cwd=concore_path)
+                else:
+                    proc= call(["./makestudy", makestudy_dir, out_dir], cwd=concore_path)
         if(proc == 0):
             resp = jsonify({'message': 'Directory successfully created'})
             resp.status_code = 201
@@ -96,8 +111,16 @@ def build(dir):
             resp.status_code = 500   
     if(platform.uname()[0]=='Windows'):
         call(["build"], cwd=dir_path, shell=True)
+        if(maxtime != None and maxtime != ''):
+            proc=call(["maxtime", maxtime],shell=True, cwd=dir_path)
+        if(params != None and params != ''):
+            proc=call(["params", params],shell=True, cwd=dir_path)
     else:
-        call(["./build"], cwd=dir_path)  
+        call(["./build"], cwd=dir_path)
+        if(maxtime != None and maxtime != ''):
+            proc=call(["./maxtime", maxtime], cwd=dir_path)
+        if(params != None and params != ''):
+            proc=call(["./params", params], cwd=dir_path)
     return resp 
 
 @app.route('/debug/<dir>', methods=['POST'])
@@ -154,12 +177,23 @@ def stop(dir):
 
 @app.route('/clear/<dir>', methods=['POST'])
 def clear(dir):
+    unlock = request.args.get('unlock')
+    params = request.args.get('params')
+    maxtime = request.args.get('maxtime')
     dir_name = secure_filename(dir)
     dir_path = os.path.abspath(os.path.join(concore_path, dir_name))
     if(platform.uname()[0]=='Windows'):
         proc=call(["clear"],shell=True, cwd=dir_path)
+        if(maxtime != None and maxtime != ''):
+            proc=call(["maxtime", maxtime],shell=True, cwd=dir_path)
+        if(params != None and params != ''):
+            proc=call(["params", params],shell=True, cwd=dir_path)
     else:
         proc = call(["./clear"], cwd=dir_path)
+        if(maxtime != None and maxtime != ''):
+            proc=call(["./maxtime", maxtime], cwd=dir_path)
+        if(params != None and params != ''):
+            proc=call(["./params", params], cwd=dir_path)
     if(proc == 0):
         resp = jsonify({'message': 'result deleted'})
         resp.status_code = 201

--- a/makedocker
+++ b/makedocker
@@ -35,5 +35,6 @@ then
     echo "either do ./destroy $studydir, or choose a unique name as 2nd arg"
 else
     echo "python3 mkconcore.py $graphml $sourcedir $studydir docker"
-    python3 mkconcore.py $graphml $sourcedir $studydir docker 
+    python3 mkconcore.py $graphml $sourcedir $studydir docker
+    chmod +x */*
 fi

--- a/makedocker.bat
+++ b/makedocker.bat
@@ -1,0 +1,18 @@
+@echo off
+if dummy%~n2 == dummy (
+ if dummy%~x1 == dummy.graphml (
+ echo python mkconcore.py %~d1%~p1%~n1%~x1 %~d1%~p1 %~n1 docker
+      python mkconcore.py %~d1%~p1%~n1%~x1 %~d1%~p1 %~n1 docker
+ ) else (
+ echo python mkconcore.py %~d1%~p1%~n1.graphml %~d1%~p1 %~n1 docker
+      python mkconcore.py %~d1%~p1%~n1.graphml %~d1%~p1 %~n1 docker
+ )
+) else (
+ if dummy%~x1 == dummy.graphml (
+ echo python mkconcore.py %~d1%~p1%~n1%~x1 %~d1%~p1 %~n2 docker
+      python mkconcore.py %~d1%~p1%~n1%~x1 %~d1%~p1 %~n2 docker
+ ) else (
+ echo python mkconcore.py %~d1%~p1%~n1.graphml %~d1%~p1 %~n2 docker
+      python mkconcore.py %~d1%~p1%~n1.graphml %~d1%~p1 %~n2 docker
+ )
+)

--- a/makestudy
+++ b/makestudy
@@ -39,8 +39,10 @@ else
     then
        echo "python3 mkconcore.py $graphml $sourcedir $studydir macos"
        python3 mkconcore.py $graphml $sourcedir $studydir macos
+       chmod +x */*
     else
        echo "python3 mkconcore.py $graphml $sourcedir $studydir ubuntu"
        python3 mkconcore.py $graphml $sourcedir $studydir ubuntu
+       chmod +x */*
     fi
 fi

--- a/mkconcore.py
+++ b/mkconcore.py
@@ -432,6 +432,7 @@ if (concoretype=="docker"):
                         fcopy.write('CMD ["./a.out"]\n')  # 7/02/21
                 fsource.close() 
 
+    fbuild.write('#!/bin/bash' + "\n")
     for node in nodes_dict:
         containername,sourcecode = nodes_dict[node].split(':')
         if len(sourcecode)!=0 and sourcecode.find(".")!=-1: #3/28/21
@@ -462,6 +463,7 @@ if (concoretype=="docker"):
 
     fbuild.close()
 
+    frun.write('#!/bin/bash' + "\n")
     i=0
     for node in nodes_dict:
         containername,sourcecode = nodes_dict[node].split(':')
@@ -482,6 +484,7 @@ if (concoretype=="docker"):
         i=i+1
     frun.close()
 
+    fstop.write('#!/bin/bash' + "\n")
     i=0 #  3/27/21
     for node in nodes_dict:
         containername,sourcecode = nodes_dict[node].split(':')
@@ -493,6 +496,7 @@ if (concoretype=="docker"):
         i=i+1
     fstop.close()
 
+    fclear.write('#!/bin/bash' + "\n")
     i=0 #  9/13/21
     for node in nodes_dict:
         containername,sourcecode = nodes_dict[node].split(':')
@@ -505,6 +509,7 @@ if (concoretype=="docker"):
         i=i+1
     fclear.close()
 
+    fmaxtime.write('#!/bin/bash' + "\n")
     fmaxtime.write('echo "$1" >concore.maxtime\n')
     fmaxtime.write('echo "FROM alpine:3.8" > Dockerfile\n')
     fmaxtime.write('sudo docker build -t docker-concore .\n')
@@ -543,6 +548,7 @@ if (concoretype=="docker"):
     fmaxtime.write('rm concore.maxtime\n')
     fmaxtime.close()
 
+    fparams.write('#!/bin/bash' + "\n")
     fparams.write('echo "$1" >concore.params\n')
     fparams.write('echo "FROM alpine:3.8" > Dockerfile\n')
     fparams.write('sudo docker build -t docker-concore .\n')
@@ -581,7 +587,7 @@ if (concoretype=="docker"):
     fparams.write('rm concore.params\n')
     fparams.close()
 
-
+    funlock.write('#!/bin/bash' + "\n")
     funlock.write('echo "FROM alpine:3.8" > Dockerfile\n')
     funlock.write('sudo docker build -t docker-concore .\n')
     funlock.write('sudo docker run --name=concore')
@@ -618,7 +624,7 @@ if (concoretype=="docker"):
     funlock.write('rm Dockerfile\n')
     funlock.close()
 
-
+    fdebug.write('#!/bin/bash' + "\n")
     i=0
     for node in nodes_dict:
         containername,sourcecode = nodes_dict[node].split(':')
@@ -873,6 +879,8 @@ for node in nodes_dict:
     i=i+1
 fmaxtime.close()
 
+if concoretype=="posix":
+    fparams.write('#!/bin/bash' + "\n")
 i=0 #  9/18/22
 for node in nodes_dict:
     containername,sourcecode = nodes_dict[node].split(':')
@@ -888,7 +896,8 @@ for node in nodes_dict:
     i=i+1
 fparams.close()
 
-
+if concoretype=="posix":
+    funlock.write('#!/bin/bash' + "\n")
 i=0 #  9/12/21
 for node in nodes_dict:
     containername,sourcecode = nodes_dict[node].split(':')


### PR DESCRIPTION
@pradeeban

- It can be noticed that "chmod +x \*/\*" is added to makestudy and makedocker scripts. It is because when I executed them in the newly installed Ubuntu 20.04, a permission denied error was coming even while executing all methods (even from CLI).

- Moreover, (after makestudy is executed) for any posix system, the interpreter directive (shebang) is not present in the scripts of params and unlock. The same goes for the case of makedocker execution, for any script created the interpreter directive (shebang) is absent. Therefore, I made some changes in [mkconcore.py](https://github.com/Rahuljagwani/concore/blob/main/mkconcore.py). If you remember in Friday's meeting I was getting an error **Exec format error: './build'**, it was because of this issue only. Even though from CLI we are able to execute them, but not from API calls.

Let me know if there are any other ways to deal with it or any changes.
Thank You