### PR TITLE
Updating deprecated actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -6,7 +6,7 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:
@@ -14,7 +14,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
fixed #130 .

Reason For Updating to v4.
1.	Security Improvements
	•	v4 includes important security enhancements over v3.
	•	Uses node20, which is more secure and maintained longer than node16 (used in v3).
2.	Performance Enhancements
	•	v4 improves speed and efficiency in both checkout and artifact upload.
3.	Longer Support
	•	v3 relies on node16, which reached its end of life in September 2023.
	•	v4 is based on node20, which has a longer support cycle.