### PR TITLE
Update: Dockerfile

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -14,7 +14,8 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
+
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/Dockerfile.java
+++ b/Dockerfile.java
@@ -1,4 +1,14 @@
-FROM openjdk:latest
-COPY . /src
-WORKDIR /src
+FROM openjdk:17-jdk-alpine
 
+WORKDIR /app
+
+# Only copy the JAR if it exists
+COPY ./target/concore-0.0.1-SNAPSHOT.jar /app/concore.jar || true
+
+# Ensure the JAR file is executable if present
+RUN [ -f /app/concore.jar ] && chmod +x /app/concore.jar || true
+
+EXPOSE 3000
+
+# Run Java app only if the JAR exists, otherwise do nothing
+CMD ["/bin/sh", "-c", "if [ -f /app/concore.jar ]; then java -jar /app/concore.jar; else echo 'No Java application found, exiting'; fi"]


### PR DESCRIPTION
Fixes: #133

Outcome:
Update Dockerfile with a more flexible structure.
Ensure the build does not break if no Java application exists.
Document the changes for future Java support.