### PR TITLE
Fix: Enable concore run execution from outside repository root

### DIFF
--- a/concore_cli/commands/run.py
+++ b/concore_cli/commands/run.py
@@ -5,10 +5,17 @@ from pathlib import Path
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+def _find_mkconcore_path():
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "mkconcore.py"
+        if candidate.exists():
+            return candidate
+    return None
+
 def run_workflow(workflow_file, source, output, exec_type, auto_build, console):
     workflow_path = Path(workflow_file).resolve()
     source_path = Path(source).resolve()
-    output_path = Path(output)
+    output_path = Path(output).resolve()
     
     if not source_path.exists():
         raise FileNotFoundError(f"Source directory '{source}' not found")
@@ -24,6 +31,10 @@ def run_workflow(workflow_file, source, output, exec_type, auto_build, console):
     console.print(f"[cyan]Type:[/cyan] {exec_type}")
     console.print()
     
+    mkconcore_path = _find_mkconcore_path()
+    if mkconcore_path is None:
+        raise FileNotFoundError("mkconcore.py not found. Please install concore from source.")
+
     with Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
@@ -33,7 +44,8 @@ def run_workflow(workflow_file, source, output, exec_type, auto_build, console):
         
         try:
             result = subprocess.run(
-                [sys.executable, 'mkconcore.py', str(workflow_path), str(source_path), str(output_path), exec_type],
+                [sys.executable, str(mkconcore_path), str(workflow_path), str(source_path), str(output_path), exec_type],
+                cwd=mkconcore_path.parent,
                 capture_output=True,
                 text=True,
                 check=True

--- a/mkconcore.py
+++ b/mkconcore.py
@@ -74,9 +74,20 @@ import numpy as np
 
 MKCONCORE_VER = "22-09-18"
 
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+def _resolve_concore_path():
+    script_concore = os.path.join(SCRIPT_DIR, "concore.py")
+    if os.path.exists(script_concore):
+        return SCRIPT_DIR
+    cwd_concore = os.path.join(os.getcwd(), "concore.py")
+    if os.path.exists(cwd_concore):
+        return os.getcwd()
+    return SCRIPT_DIR
+
 GRAPHML_FILE = sys.argv[1]
 TRIMMED_LOGS = True
-CONCOREPATH = "."
+CONCOREPATH = _resolve_concore_path()
 CPPWIN    = "g++"        #Windows C++  6/22/21
 CPPEXE    = "g++"        #Ubuntu/macOS C++  6/22/21
 VWIN      = "iverilog"   #Windows verilog  6/25/21

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,7 +67,22 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(cli, ['init', 'test-project'])
             result = self.runner.invoke(cli, ['run', 'test-project/workflow.graphml', '--source', 'nonexistent'])
             self.assertNotEqual(result.exit_code, 0)
-    
+
+    def test_run_command_from_project_dir(self):
+        with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
+            result = self.runner.invoke(cli, ['init', 'test-project'])
+            self.assertEqual(result.exit_code, 0)
+
+            result = self.runner.invoke(cli, [
+                'run',
+                'test-project/workflow.graphml',
+                '--source', 'test-project/src',
+                '--output', 'out',
+                '--type', 'posix'
+            ])
+            self.assertEqual(result.exit_code, 0)
+            self.assertTrue(Path('out/src/concore.py').exists())
+
     def test_run_command_existing_output(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ['init', 'test-project'])


### PR DESCRIPTION
Hi @pradeeban , 
I hope you're doing well! I'm submitting this PR to fix a critical issue where `concore run` fails when executed outside the repository root. This blocks the standard user workflow (creating and running projects in separate directories).

This PR fixes the path resolution logic so the CLI works correctly from any location, as documented in the README.

Fixes #214 

## Why this change?
`concore run` is documented as a CLI workflow step, but it only worked if you executed it from the repo root.  
In real usage (`concore init`, `cd my-project`, `concore run workflow.graphml`), the command fails because:
- `mkconcore.py` is referenced by filename only (not resolvable from a project dir)
- `mkconcore.py` looks for concore assets (`concore.py`, `concore.hpp`, etc.) relative to CWD

This breaks the Quick Start and makes the CLI unusable when installed normally.

---

## What was the problem?
- **CLI invoked mkconcore by relative path** → `mkconcore.py` not found outside repo root  
- **mkconcore assets resolved from CWD** → `concore.py`/`concore.hpp`/`concore.v` not found  
- **Result:** `concore run` failed in the exact flow shown in `concore_cli/README.md`

---

## How I solved it
1. **Resolved mkconcore by absolute path** in `concore_cli/commands/run.py`  
2. **Passed absolute paths** for workflow, source, and output  
3. **Set `cwd` to mkconcore’s directory** to preserve existing relative lookups  
4. **Made mkconcore resolve assets relative to its own file** (fallback to CWD for backward compatibility)  
5. **Added an integration test** that runs `concore run` from a temp project directory and asserts output is generated

---

## Changes / Implementation
- `concore_cli/commands/run.py`
  - New `_find_mkconcore_path()` search logic
  - Absolute path invocation + `cwd` correction
- `mkconcore.py`
  - `SCRIPT_DIR` + `_resolve_concore_path()` to locate assets robustly
- `tests/test_cli.py`
  - New integration test: `test_run_command_from_project_dir`

---

## How to Test Locally
1. Install deps  
pip install -r requirements.txt
pip install -r requirements-dev.txt


2. Run tests  
python -m pytest -v tests/test_cli.py


or full suite  
python -m pytest -v



---

## Evidence
- `python -m pytest -v tests/test_cli.py` (10 tests passed)
<img width="1914" height="494" alt="Screenshot 2026-02-07 031513" src="https://github.com/user-attachments/assets/34aa5a87-04dc-4fd9-a992-3b9f21deef30" />


---

## PR Checklist
- [x] Added tests for the new behavior  
- [x] Ran tests locally (`python -m pytest -v tests/test_cli.py`)  
- [x] No public API changes  
- [x] Works from a standard project directory (not just repo root)

## Note to Maintainers
I’m happy to adjust the approach if you prefer a different path‑resolution strategy or packaging layout. Please share any feedback on structure or style and I’ll iterate quickly.
