### PR TITLE
add tests for gaphml with strict xml checks

### DIFF
--- a/concore_cli/commands/validate.py
+++ b/concore_cli/commands/validate.py
@@ -3,6 +3,7 @@ from bs4 import BeautifulSoup
 from rich.panel import Panel
 from rich.table import Table
 import re
+import xml.etree.ElementTree as ET
 
 def validate_workflow(workflow_file, console):
     workflow_path = Path(workflow_file)
@@ -22,15 +23,34 @@ def validate_workflow(workflow_file, console):
             errors.append("File is empty")
             return show_results(console, errors, warnings, info)
         
+        # strict XML syntax check
+        try:
+            ET.fromstring(content)
+        except ET.ParseError as e:
+            errors.append(f"Invalid XML: {str(e)}")
+            return show_results(console, errors, warnings, info)
+        
         try:
             soup = BeautifulSoup(content, 'xml')
         except Exception as e:
             errors.append(f"Invalid XML: {str(e)}")
             return show_results(console, errors, warnings, info)
         
-        if not soup.find('graphml'):
+        root = soup.find('graphml')
+        if not root:
             errors.append("Not a valid GraphML file - missing <graphml> root element")
             return show_results(console, errors, warnings, info)
+            
+        # check the graph attributes
+        graph = soup.find('graph')
+        if not graph:
+             errors.append("Missing <graph> element")
+        else:
+             edgedefault = graph.get('edgedefault')
+             if not edgedefault:
+                 errors.append("Graph missing required 'edgedefault' attribute")
+             elif edgedefault not in ['directed', 'undirected']:
+                 errors.append(f"Invalid edgedefault value '{edgedefault}' (must be 'directed' or 'undirected')")
         
         nodes = soup.find_all('node')
         edges = soup.find_all('edge')
@@ -47,8 +67,19 @@ def validate_workflow(workflow_file, console):
         
         node_labels = []
         for node in nodes:
+            #check the node id
+            node_id = node.get('id')
+            if not node_id:
+                errors.append("Node missing required 'id' attribute")
+                #skip further checks for this node to avoid noise
+                continue
+
             try:
+                #robust find: try with namespace prefix first, then without
                 label_tag = node.find('y:NodeLabel')
+                if not label_tag:
+                    label_tag = node.find('NodeLabel')
+                
                 if label_tag and label_tag.text:
                     label = label_tag.text.strip()
                     node_labels.append(label)
@@ -60,13 +91,13 @@ def validate_workflow(workflow_file, console):
                         if len(parts) != 2:
                             warnings.append(f"Node '{label}' has invalid format")
                         else:
-                            node_id, filename = parts
+                            nodeId_part, filename = parts
                             if not filename:
                                 errors.append(f"Node '{label}' has no filename")
                             elif not any(filename.endswith(ext) for ext in ['.py', '.cpp', '.m', '.v', '.java']):
                                 warnings.append(f"Node '{label}' has unusual file extension")
                 else:
-                    warnings.append(f"Node {node.get('id', 'unknown')} has no label")
+                    warnings.append(f"Node {node_id} has no label")
             except Exception as e:
                 warnings.append(f"Error parsing node: {str(e)}")
         
@@ -91,6 +122,9 @@ def validate_workflow(workflow_file, console):
         for edge in edges:
             try:
                 label_tag = edge.find('y:EdgeLabel')
+                if not label_tag:
+                    label_tag = edge.find('EdgeLabel')
+                    
                 if label_tag and label_tag.text:
                     if edge_label_regex.match(label_tag.text.strip()):
                         zmq_edges += 1

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,133 @@
+import unittest
+import tempfile
+import shutil
+from pathlib import Path
+from click.testing import CliRunner
+from concore_cli.cli import cli
+
+class TestGraphValidation(unittest.TestCase):
+    
+    def setUp(self):
+        self.runner = CliRunner()
+        self.temp_dir = tempfile.mkdtemp()
+    
+    def tearDown(self):
+        if Path(self.temp_dir).exists():
+            shutil.rmtree(self.temp_dir)
+            
+    def create_graph_file(self, filename, content):
+        filepath = Path(self.temp_dir) / filename
+        with open(filepath, 'w') as f:
+            f.write(content)
+        return str(filepath)
+
+    def test_validate_corrupted_xml(self):
+        content = '<graphml><node id="n0">'
+        filepath = self.create_graph_file('corrupted.graphml', content)
+        
+        result = self.runner.invoke(cli, ['validate', filepath])
+        
+        self.assertIn('Validation failed', result.output)
+        self.assertIn('Invalid XML', result.output)
+
+    def test_validate_empty_file(self):
+        filepath = self.create_graph_file('empty.graphml', '')
+        
+        result = self.runner.invoke(cli, ['validate', filepath])
+        
+        self.assertIn('Validation failed', result.output)
+        self.assertIn('File is empty', result.output)
+    
+    def test_validate_missing_node_id(self):
+        content = '''
+        <graphml xmlns:y="http://www.yworks.com/xml/graphml">
+            <graph id="G" edgedefault="directed">
+                <node>
+                    <data key="d0"><y:NodeLabel>n0:script.py</y:NodeLabel></data>
+                </node>
+            </graph>
+        </graphml>
+        '''
+        filepath = self.create_graph_file('missing_id.graphml', content)
+        result = self.runner.invoke(cli, ['validate', filepath])
+        self.assertIn('Validation failed', result.output)
+        self.assertIn("Node missing required 'id' attribute", result.output)
+
+    def test_validate_missing_edgedefault(self):
+        content = '''
+        <graphml xmlns:y="http://www.yworks.com/xml/graphml">
+            <graph id="G">
+                <node id="n0">
+                    <data key="d0"><y:NodeLabel>n0:script.py</y:NodeLabel></data>
+                </node>
+            </graph>
+        </graphml>
+        '''
+        filepath = self.create_graph_file('missing_default.graphml', content)
+        result = self.runner.invoke(cli, ['validate', filepath])
+        self.assertIn('Validation failed', result.output)
+        self.assertIn("Graph missing required 'edgedefault'", result.output)
+
+    def test_validate_missing_root_element(self):
+        content = '<?xml version="1.0"?><other_root></other_root>'
+        filepath = self.create_graph_file('not_graphml.xml', content)
+        
+        result = self.runner.invoke(cli, ['validate', filepath])
+        
+        self.assertIn('Validation failed', result.output)
+        self.assertIn('missing <graphml> root element', result.output)
+
+    def test_validate_broken_edges(self):
+        content = '''
+        <graphml xmlns:y="http://www.yworks.com/xml/graphml">
+            <graph id="G" edgedefault="directed">
+                <node id="n0">
+                    <data key="d0"><y:NodeLabel>n0:script.py</y:NodeLabel></data>
+                </node>
+                <edge source="n0" target="n1"/>
+            </graph>
+        </graphml>
+        '''
+        filepath = self.create_graph_file('bad_edge.graphml', content)
+        
+        result = self.runner.invoke(cli, ['validate', filepath])
+        
+        self.assertIn('Validation failed', result.output)
+        self.assertIn('Edge references non-existent target node', result.output)
+
+    def test_validate_node_missing_filename(self):
+        content = '''
+        <graphml xmlns:y="http://www.yworks.com/xml/graphml">
+            <graph id="G" edgedefault="directed">
+                <node id="n0">
+                    <data key="d0"><y:NodeLabel>n0:</y:NodeLabel></data>
+                </node>
+            </graph>
+        </graphml>
+        '''
+        filepath = self.create_graph_file('bad_node.graphml', content)
+        
+        result = self.runner.invoke(cli, ['validate', filepath])
+        
+        self.assertIn('Validation failed', result.output)
+        self.assertIn('has no filename', result.output)
+
+    def test_validate_valid_graph(self):
+        content = '''
+        <graphml xmlns:y="http://www.yworks.com/xml/graphml">
+            <graph id="G" edgedefault="directed">
+                <node id="n0">
+                    <data key="d0"><y:NodeLabel>n0:script.py</y:NodeLabel></data>
+                </node>
+            </graph>
+        </graphml>
+        '''
+        filepath = self.create_graph_file('valid.graphml', content)
+        
+        result = self.runner.invoke(cli, ['validate', filepath])
+        
+        self.assertIn('Validation passed', result.output)
+        self.assertIn('Workflow is valid', result.output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In this PR, I have added tests for graphml file in tests/test_graph.py:
- test_validate_corrupted_xml: test for files with unclosed tags
- test_validate_empty_file: test for empty file
- test_validate_missing_root_element: incase there is XML file but it is not a graphml file
- test_validate_missing_node_id: test for node id attributes
- test_validate_missing_edgedefault
- test_validate_broken_edges: test for cases like edge exists but the node is missing
- test_validate_node_missing_filename: for test case like node exists but it isn't linked to any concore program
- test_validate_valid_graph: test case for a perfectly minimal graphml file

the major changes in the validate.py:
- added xml.etree.ElementTree to detect and report broken XML syntax immediately.
- Added mandatory checks for:
-- The edgedefault attribute on the <graph> element, it has to be directed or undirected.
--The node "id" attribute on every <node>, every node must have node id.

<img width="1017" height="839" alt="image" src="https://github.com/user-attachments/assets/bb66840a-eb9f-4ecf-b6d2-86881c26e9fe" />

I have checked these test by building some dummy sample graphs:
1) empty graph shows warning-> no nodes, no edges
<img width="1796" height="599" alt="image" src="https://github.com/user-attachments/assets/1980b3c0-5762-48df-9342-07212c440843" />
<img width="1045" height="304" alt="image" src="https://github.com/user-attachments/assets/c458ed10-8271-4919-8141-efa1068ce5d3" />

2) graph with just node (no program attached with it) but no edge
<img width="1863" height="664" alt="image" src="https://github.com/user-attachments/assets/3ca73229-9331-4ba0-a184-39f047da5cd3" />
<img width="1047" height="366" alt="image" src="https://github.com/user-attachments/assets/a6d8ad0b-a888-4cca-af07-8bdcb6762699" />

3) <img width="1681" height="578" alt="image" src="https://github.com/user-attachments/assets/f8cc53fb-2af9-4073-abcc-a97777fa0b5c" />
<img width="417" height="257" alt="image" src="https://github.com/user-attachments/assets/f63a0b6e-fe4d-45cd-833c-82d25751cbcb" />

4) <img width="512" height="167" alt="image" src="https://github.com/user-attachments/assets/f3709533-fbd1-4ce5-b4eb-ad3552183f06" />
<img width="563" height="226" alt="image" src="https://github.com/user-attachments/assets/d394dc9c-bd01-4bfe-a959-def937b58a15" />

5) <img width="729" height="290" alt="image" src="https://github.com/user-attachments/assets/95b4182e-14eb-4297-89b7-312e12e35687" />
<img width="618" height="329" alt="image" src="https://github.com/user-attachments/assets/a6359835-dad7-4944-a9b6-24af9016de65" />



