### PR TITLE
Register terminate_zmq with atexit to cleanup sockets on exit

### DIFF
--- a/concore.py
+++ b/concore.py
@@ -1,6 +1,7 @@
 import time
 import logging
 import os
+import atexit
 from ast import literal_eval
 import sys
 import re
@@ -104,6 +105,8 @@ def terminate_zmq():
             port.context.term()
         except Exception as e:
             logging.error(f"Error while terminating ZMQ port {port.address}: {e}")
+
+atexit.register(terminate_zmq)
 # --- ZeroMQ Integration End ---
 
 


### PR DESCRIPTION
Added [atexit.register(terminate_zmq)](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so ZMQ sockets get closed automatically when the script ends. Without this, sockets stay open if someone forgets to call it manually or the program crashes, causing "address already in use" errors on restart.

Fixes #203