### PR TITLE
Add pyzmq dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4
 lxml
 tensorflow
 numpy
+pyzmq
 scipy
 matplotlib
 cvxopt

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "beautifulsoup4",
         "lxml",
         "numpy",
+        "pyzmq",
         "scipy",
         "matplotlib",
         "click>=8.0.0",


### PR DESCRIPTION
Added pyzmq to requirements.txt and setup.py. The code imports zmq on line 7 but the dependency wasn't listed, causing ModuleNotFoundError on fresh installs.

Fixes #211