### PR TITLE
Fix sample script to use correct concore function names

### DIFF
--- a/concore_cli/commands/init.py
+++ b/concore_cli/commands/init.py
@@ -25,10 +25,17 @@ SAMPLE_GRAPHML = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 SAMPLE_PYTHON = '''import concore
 
-while not concore.concore_unchanged():
-    data = concore.concore_read()
-    result = data * 2
-    concore.concore_write(result)
+concore.default_maxtime(100)
+concore.delay = 0.02
+
+init_simtime_val = "[0.0, 0.0]"
+val = concore.initval(init_simtime_val)
+
+while(concore.simtime<concore.maxtime):
+    while concore.unchanged():
+        val = concore.read(1,"data",init_simtime_val)
+    result = [v * 2 for v in val]
+    concore.write(1,"result",result,delta=0)
 '''
 
 README_TEMPLATE = '''# {project_name}


### PR DESCRIPTION
The sample script.py generated by `concore init` was using MATLAB-style function names (`concore_unchanged`, `concore_read`, `concore_write`) that don't exist in Python. Changed it to use the actual function names ([unchanged](cci:1://file:///d:/gsoc%20org/concore-project/concore/concoredocker.java:72:4-78:5), [read](cci:1://file:///d:/gsoc%20org/concore-project/concore/concoredocker.java:88:4-103:5), [write](cci:1://file:///d:/gsoc%20org/concore-project/concore/concoredocker.java:105:4-133:5)) and added the required initialization pattern from the existing demos

this Fixes #223