### PR TITLE
Add missing pyzmq dependency for unconditional zmq import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scipy
 matplotlib
 cvxopt
 PyGithub
+pyzmq


### PR DESCRIPTION
## Summary
`concore.py` imports `zmq` unconditionally at line 6, but the corresponding 
package `pyzmq` was missing from `requirements.txt`. This causes a fresh 
install to fail with `ModuleNotFoundError: No module named 'zmq'`.

## Fix
- Add `pyzmq` to `requirements.txt`

## Verification
- Confirmed baseline failure: `python -c "import concore"` → `ModuleNotFoundError`
- After fix: `python -c "import concore"` → Success

## Impact
- Fixes fresh installs
- No runtime behavior changes
- Safe, minimal dependency fix

Fixes #227