### PR TITLE
Fix broken functions in concoredocker.hpp to match Python behavior

### DIFF
--- a/concoredocker.hpp
+++ b/concoredocker.hpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <stdexcept>
 #include <regex>
+#include <algorithm>
 
 class Concore {
 public:
@@ -26,6 +27,52 @@ public:
     int maxtime = 100;
     std::unordered_map<std::string, std::string> params;
 
+    std::string stripstr(const std::string& str) {
+        size_t start = str.find_first_not_of(" \t\n\r");
+        if (start == std::string::npos) return "";
+        size_t end = str.find_last_not_of(" \t\n\r");
+        return str.substr(start, end - start + 1);
+    }
+
+    std::string stripquotes(const std::string& str) {
+        if (str.size() >= 2 && ((str.front() == '\'' && str.back() == '\'') || (str.front() == '"' && str.back() == '"')))
+            return str.substr(1, str.size() - 2);
+        return str;
+    }
+
+    std::unordered_map<std::string, std::string> parsedict(const std::string& str) {
+        std::unordered_map<std::string, std::string> result;
+        std::string trimmed = stripstr(str);
+        if (trimmed.size() < 2 || trimmed.front() != '{' || trimmed.back() != '}')
+            return result;
+        std::string inner = trimmed.substr(1, trimmed.size() - 2);
+        std::stringstream ss(inner);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            size_t colon = token.find(':');
+            if (colon == std::string::npos) continue;
+            std::string key = stripquotes(stripstr(token.substr(0, colon)));
+            std::string val = stripquotes(stripstr(token.substr(colon + 1)));
+            if (!key.empty()) result[key] = val;
+        }
+        return result;
+    }
+
+    std::vector<std::string> parselist(const std::string& str) {
+        std::vector<std::string> result;
+        std::string trimmed = stripstr(str);
+        if (trimmed.size() < 2 || trimmed.front() != '[' || trimmed.back() != ']')
+            return result;
+        std::string inner = trimmed.substr(1, trimmed.size() - 2);
+        std::stringstream ss(inner);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            std::string val = stripstr(token);
+            if (!val.empty()) result.push_back(val);
+        }
+        return result;
+    }
+
     Concore() {
         iport = safe_literal_eval("concore.iport", {});
         oport = safe_literal_eval("concore.oport", {});
@@ -39,7 +86,14 @@ public:
             std::cerr << "Error reading " << filename << "\n";
             return defaultValue;
         }
-        return defaultValue;
+        std::stringstream buf;
+        buf << file.rdbuf();
+        std::string content = buf.str();
+        try {
+            return parsedict(content);
+        } catch (...) {
+            return defaultValue;
+        }
     }
 
     void load_params() {
@@ -54,8 +108,11 @@ public:
         }
 
         if (!sparams.empty() && sparams[0] != '{') {
-            sparams = "{'" + std::regex_replace(std::regex_replace(std::regex_replace(sparams, std::regex(","), ", '"), std::regex("="), "':"), std::regex(" "), "") + "}";
+            sparams = "{\"" + std::regex_replace(std::regex_replace(std::regex_replace(sparams, std::regex(","), ",\""), std::regex("="), "\":"), std::regex(" "), "") + "}";
         }
+        try {
+            params = parsedict(sparams);
+        } catch (...) {}
     }
 
     std::string tryparam(const std::string& n, const std::string& i) {
@@ -106,6 +163,14 @@ public:
         }
         
         s += ins;
+        try {
+            std::vector<std::string> inval = parselist(ins);
+            if (!inval.empty()) {
+                int file_simtime = (int)std::stod(inval[0]);
+                simtime = std::max(simtime, file_simtime);
+                return std::vector<std::string>(inval.begin() + 1, inval.end());
+            }
+        } catch (...) {}
         return {ins};
     }
 
@@ -124,6 +189,17 @@ public:
             outfile << "]";
             simtime += delta;
         }
+    }
+
+    std::vector<std::string> initval(const std::string& simtime_val) {
+        try {
+            std::vector<std::string> val = parselist(simtime_val);
+            if (!val.empty()) {
+                simtime = (int)std::stod(val[0]);
+                return std::vector<std::string>(val.begin() + 1, val.end());
+            }
+        } catch (...) {}
+        return {};
     }
 };
 


### PR DESCRIPTION
Fixed four critical bugs where C++ functions weren't actually doing anything. [safe_literal_eval()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now reads files, [load_params()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) populates the map, [read()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) extracts simtime and returns data and added missing [initval()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). All helper functions renamed to match the codebase style (no underscores).

Fixes #224