### PR TITLE
Fix: add missing return after ZMQ send in write() - Fixes #238

### DIFF
--- a/concore.py
+++ b/concore.py
@@ -333,6 +333,7 @@ def write(port_identifier, name, val, delta=0):
             logging.error(f"ZMQ write error on port {port_identifier} (name: {name}): {e}")
         except Exception as e:
             logging.error(f"Unexpected error during ZMQ write on port {port_identifier} (name: {name}): {e}")
+        return
     
     # Case 2: File-based port
     try:


### PR DESCRIPTION
Fixes #238

The write() function was missing a return statement after the ZMQ send path, causing execution to fall through into the file-based write logic. This led to redundant file operations after every ZMQ write.

Added return to match the pattern already used in read()