### PR TITLE
Fix MATLAB retry loop hang and crashes in concore_read.m

### DIFF
--- a/concore_read.m
+++ b/concore_read.m
@@ -8,12 +8,21 @@ function [result] = concore_read(port, name, inistr)
      catch exc
          ins = inistr;
      end
-     while length(ins) == 0
+     maxretries = 5;
+     attempts = 0;
+     while length(ins) == 0 && attempts < maxretries
          pause(concore.delay);
-         input1 = fopen(strcat(concore.inpath,num2str(port),'/',name));
-         ins = fscanf(input1,'%c');
-         fclose(input1);
+         try
+             input1 = fopen(strcat(concore.inpath,num2str(port),'/',name));
+             ins = fscanf(input1,'%c');
+             fclose(input1);
+         catch exc
+         end
          concore.retrycount = concore.retrycount + 1;
+         attempts = attempts + 1;
+     end
+     if length(ins) == 0
+         ins = inistr;
      end
      concore.s = strcat(concore.s, ins);
      result = eval(ins);


### PR DESCRIPTION
The retry loop in [concore_read.m](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) had no max retry limit and no error handling around file operations. If a file stayed empty or fopen failed during retries, the loop would either hang forever or crash the whole function.

Added a 5-retry cap (matching the Python implementation) and wrapped the retry loop body in try-catch to handle file errors gracefully. Falls back to the default value if retries are exhausted.

Fixes #239