### PR TITLE
fix(java): rewrite literalEval() with recursive descent parser

### DIFF
--- a/TestLiteralEval.java
+++ b/TestLiteralEval.java
@@ -4,7 +4,7 @@ import java.util.*;
  * Test suite for concoredocker.literalEval() recursive descent parser.
  * Covers: dicts, lists, tuples, numbers, strings, booleans, None,
  *         nested structures, escape sequences, scientific notation,
- *         toPythonLiteral serialization, and fractional simtime.
+ *         fractional simtime, and related round-trip parsing behavior.
  */
 public class TestLiteralEval {
     static int passed = 0;
@@ -36,6 +36,7 @@ public class TestLiteralEval {
         testUnterminatedList();
         testUnterminatedDict();
         testUnterminatedTuple();
+        testNonStringDictKey();
 
         System.out.println("\n=== Results: " + passed + " passed, " + failed + " failed out of " + (passed + failed) + " tests ===");
         if (failed > 0) {
@@ -198,15 +199,7 @@ public class TestLiteralEval {
     // --- Round-trip serialization tests ---
 
     static void testRoundTripSerialization() {
-        // Serialize a list with mixed types, then re-parse and verify
-        List<Object> original = new ArrayList<>();
-        original.add(1);
-        original.add(2.5);
-        original.add(true);
-        original.add(false);
-        original.add(null);
-        original.add("hello");
-
+        // Conceptually: a list with mixed types [1, 2.5, true, false, null, "hello"]
         // Use reflection-free approach: build the Python literal manually
         // and verify round-trip through literalEval
         String serialized = "[1, 2.5, True, False, None, 'hello']";
@@ -261,6 +254,17 @@ public class TestLiteralEval {
             failed++;
         } catch (IllegalArgumentException e) {
             check("unterminated tuple throws", true, e.getMessage().contains("Unterminated tuple"));
+        }
+    }
+
+    static void testNonStringDictKey() {
+        // Dict keys must be strings - numeric keys should throw
+        try {
+            concoredocker.literalEval("{123: 'value'}");
+            System.out.println("FAIL: numeric dict key should throw");
+            failed++;
+        } catch (IllegalArgumentException e) {
+            check("numeric dict key throws", true, e.getMessage().contains("Dict keys must be non-null strings"));
         }
     }
 }

--- a/concoredocker.java
+++ b/concoredocker.java
@@ -41,25 +41,39 @@ public class concoredocker {
         }
 
         try {
-            String sparams = new String(Files.readAllBytes(Paths.get(inpath + "1/concore.params")));
+            String sparams = new String(Files.readAllBytes(Paths.get(inpath + "1/concore.params")), java.nio.charset.StandardCharsets.UTF_8);
             if (sparams.length() > 0 && sparams.charAt(0) == '"') { // windows keeps "" need to remove
                 sparams = sparams.substring(1);
                 sparams = sparams.substring(0, sparams.indexOf('"'));
             }
-            if (!sparams.equals("{")) {
+            // Try parsing as dict literal first (matches Python parse_params logic)
+            sparams = sparams.trim();
+            if (sparams.startsWith("{") && sparams.endsWith("}")) {
+                try {
+                    Object parsed = literalEval(sparams);
+                    if (parsed instanceof Map) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> parsedMap = (Map<String, Object>) parsed;
+                        params = parsedMap;
+                    }
+                } catch (Exception e) {
+                    System.out.println("bad params: " + sparams);
+                }
+            } else if (!sparams.isEmpty()) {
+                // Fallback: convert key=value,key=value format to dict
                 System.out.println("converting sparams: " + sparams);
                 sparams = "{'" + sparams.replaceAll(",", ",'").replaceAll("=", "':").replaceAll(" ", "") + "}";
                 System.out.println("converted sparams: " + sparams);
-            }
-            try {
-                Object parsed = literalEval(sparams);
-                if (parsed instanceof Map) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> parsedMap = (Map<String, Object>) parsed;
-                    params = parsedMap;
+                try {
+                    Object parsed = literalEval(sparams);
+                    if (parsed instanceof Map) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> parsedMap = (Map<String, Object>) parsed;
+                        params = parsedMap;
+                    }
+                } catch (Exception e) {
+                    System.out.println("bad params: " + sparams);
                 }
-            } catch (Exception e) {
-                System.out.println("bad params: " + sparams);
             }
         } catch (IOException e) {
             params = new HashMap<>();
@@ -73,7 +87,7 @@ public class concoredocker {
      * Returns empty map if file is empty or malformed (matches Python safe_literal_eval).
      */
     private static Map<String, Object> parseFile(String filename) throws IOException {
-        String content = new String(Files.readAllBytes(Paths.get(filename)));
+        String content = new String(Files.readAllBytes(Paths.get(filename)), java.nio.charset.StandardCharsets.UTF_8);
         content = content.trim();
         if (content.isEmpty()) {
             return new HashMap<>();
@@ -182,7 +196,6 @@ public class concoredocker {
 
         if (ins.length() == 0) {
             System.out.println("Max retries reached for " + filePath + ", using default value.");
-            s += initstr;
             return defaultVal;
         }
 
@@ -197,7 +210,6 @@ public class concoredocker {
         } catch (Exception e) {
             System.out.println("Error parsing " + ins + ": " + e.getMessage());
         }
-        s += initstr;
         return defaultVal;
     }
 
@@ -404,7 +416,12 @@ public class concoredocker {
                 pos++; // skip ':'
                 skipWhitespace();
                 Object value = parseExpression();
-                map.put(key.toString(), value);
+                if (!(key instanceof String)) {
+                    throw new IllegalArgumentException(
+                        "Dict keys must be non-null strings, but got: "
+                        + (key == null ? "null" : key.getClass().getSimpleName()));
+                }
+                map.put((String) key, value);
                 skipWhitespace();
                 if (pos >= input.length()) {
                     throw new IllegalArgumentException("Unterminated dict: missing '}'");


### PR DESCRIPTION
This PR fixes #228 related to the `literalEval()` implementation in `concoredocker.java`.

The previous implementation was using `String.split(",")`, which caused problems in several situations such as nested structures (like lists inside dictionaries), strings containing commas or colons, and cases with escape sequences. Because of this, some valid Python literals were not being parsed correctly.

To fix this, I replaced the logic with a recursive descent parser that can properly handle Python literal syntax. I also added an `escapePythonString()` method for correct string escaping and updated `toPythonLiteral()` so it uses Python values like `True`, `False`, and `None`.

Some additional fixes were also made:
- `read()` now returns `List<Object>` and includes a retry mechanism
- `write()` delay is changed to `double` instead of `int`, with separate catch blocks
- `simtime` type is updated to `double`

I also added a test file `TestLiteralEval.java` with 49 test cases to verify different scenarios.

All 49 tests pass locally.

This PR contains only the Java files as requested:
- `concoredocker.java` (fixed implementation)
- `TestLiteralEval.java` (test suite)

Fixes #228