### PR TITLE
fix(ci): add missing dependencies to requirements-ci.txt

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,3 +4,8 @@ pytest
 ruff
 pyzmq
 numpy
+click>=8.0.0
+rich>=10.0.0
+psutil>=5.8.0
+beautifulsoup4
+lxml


### PR DESCRIPTION
Hey pradeeban Sir,

This PR fixes the CI test import errors by adding some missing dependencies.

The CI `lint-and-test` workflow currently fails with:

ModuleNotFoundError: No module named 'click'

Because of this error the tests are not able to run and the CI checks fail.

To fix this, I added the required dependencies to `requirements-ci.txt`:

- click>=8.0.0 – used in `tests/test_cli.py`
- rich>=10.0.0 – required for CLI output
- psutil>=5.8.0 – used by runtime utilities
- beautifulsoup4 – used in `tests/test_graph.py`
- lxml – required as the XML parser

Note: This PR is kept separate from **PR #252** (Java `literalEval` fix) as suggested, so that each PR focuses on a single change.