### PR TITLE
Fix ZMQ write JSON serialization for NumPy types, add regression test

### DIFF
--- a/concore.py
+++ b/concore.py
@@ -373,7 +373,9 @@ def write(port_identifier, name, val, delta=0):
     if isinstance(port_identifier, str) and port_identifier in zmq_ports:
         zmq_p = zmq_ports[port_identifier]
         try:
-            zmq_p.send_json_with_retry(val)
+            # Keep ZMQ payloads JSON-serializable by normalizing numpy types.
+            zmq_val = convert_numpy_to_python(val)
+            zmq_p.send_json_with_retry(zmq_val)
         except zmq.error.ZMQError as e:
             logging.error(f"ZMQ write error on port {port_identifier} (name: {name}): {e}")
         except Exception as e:

--- a/mkconcore.py
+++ b/mkconcore.py
@@ -75,15 +75,21 @@ import numpy as np
 import shlex  # Added for POSIX shell escaping
 
 # input validation helper
-def safe_name(value, context):
+def safe_name(value, context, allow_path=False):
     """
     Validates that the input string does not contain characters dangerous 
     for filesystem paths or shell command injection.
     """
     if not value:
         raise ValueError(f"{context} cannot be empty")
-    # blocks path traversal (/, \), control characters, and shell metacharacters (*, ?, <, >, |, ;, &, $, `, ', ", (, ))
-    if re.search(r'[\x00-\x1F\x7F\\/:*?"<>|;&`$\'()]', value):
+    # blocks control characters and shell metacharacters
+    # allow path separators and drive colons for full paths when needed
+    if allow_path:
+        pattern = r'[\x00-\x1F\x7F*?"<>|;&`$\'()]'
+    else:
+        # blocks path traversal (/, \, :) in addition to shell metacharacters
+        pattern = r'[\x00-\x1F\x7F\\/:*?"<>|;&`$\'()]'
+    if re.search(pattern, value):
         raise ValueError(f"Unsafe {context}: '{value}' contains illegal characters.")
     return value
 
@@ -146,8 +152,8 @@ prefixedgenode = ""
 sourcedir = sys.argv[2]
 outdir = sys.argv[3]
 
-# Validate outdir argument
-safe_name(outdir, "Output directory argument")
+# Validate outdir argument (allow full paths)
+safe_name(outdir, "Output directory argument", allow_path=True)
 
 if not os.path.isdir(sourcedir):
     logging.error(f"{sourcedir} does not exist")

--- a/tests/test_concore.py
+++ b/tests/test_concore.py
@@ -212,3 +212,35 @@ class TestParseParams:
         s = s[1:-1]  # simulate quote stripping before parse_params
         params = parse_params(s)
         assert params == {"a": 1, "b": 2}
+
+
+class TestWriteZMQ:
+    @pytest.fixture(autouse=True)
+    def reset_zmq_ports(self):
+        import concore
+        original_ports = concore.zmq_ports.copy()
+        yield
+        concore.zmq_ports.clear()
+        concore.zmq_ports.update(original_ports)
+
+    def test_write_converts_numpy_types_for_zmq(self):
+        import concore
+
+        class DummyPort:
+            def __init__(self):
+                self.sent = None
+
+            def send_json_with_retry(self, message):
+                self.sent = message
+
+        dummy = DummyPort()
+        concore.zmq_ports["test_zmq"] = dummy
+
+        payload = [np.int64(7), np.float64(3.5), {"x": np.float32(1.25)}]
+        concore.write("test_zmq", "data", payload)
+
+        assert dummy.sent is not None
+        assert dummy.sent == [7, 3.5, {"x": 1.25}]
+        assert not isinstance(dummy.sent[0], np.generic)
+        assert not isinstance(dummy.sent[1], np.generic)
+        assert not isinstance(dummy.sent[2]["x"], np.generic)


### PR DESCRIPTION
## Why this change?
ZMQ `write()` sends raw NumPy values to `send_json_with_retry()`, which is not JSON-serializable. This causes ZMQ messages to fail silently when payloads include NumPy scalars or arrays. File-based `write()` already normalizes NumPy types, so behavior is inconsistent.

---

## What was the problem?
- ZMQ path in `concore.write()` sends raw `val`
- JSON serialization fails for `numpy.float64`, `numpy.int64`, arrays, dicts with NumPy values
- Mixed or ZMQ-only studies break at runtime without a clear error

---

## How I solved it
1. Normalized ZMQ payloads using `convert_numpy_to_python()` before `send_json_with_retry()`
2. Added a regression test that mocks a ZMQ port and asserts plain Python types are sent
3. Fixed a `mkconcore.py` regression from latest `dev` where absolute output paths were rejected by `safe_name` (needed for CLI test to pass)

---

## Changes / Implementation
- `concore.py`
  - Convert NumPy values before ZMQ JSON send
- `tests/test_concore.py`
  - New `TestWriteZMQ` to verify conversion and JSON-safe payload
- `mkconcore.py`
  - Allow full paths for output directory in `safe_name` while still blocking shell metacharacters

---

## How to Test Locally
python -m pytest -v tests/test_concore.py
python -m pytest -v



---

## PR Checklist
- [x] Added tests for the new behavior  
- [x] Ran full test suite locally  
- [x] No public API changes  
- [x] Fix is backwards-compatible
