### PR TITLE
Fix default execution type in CLI and add test for run command

### DIFF
--- a/concore_cli/cli.py
+++ b/concore_cli/cli.py
@@ -1,5 +1,6 @@
 import click
 from rich.console import Console
+import os
 import sys
 
 from .commands.init import init_project
@@ -10,6 +11,7 @@ from .commands.stop import stop_all
 from .commands.inspect import inspect_workflow
 
 console = Console()
+DEFAULT_EXEC_TYPE = 'windows' if os.name == 'nt' else 'posix'
 
 @click.group()
 @click.version_option(version='1.0.0', prog_name='concore')
@@ -31,7 +33,7 @@ def init(name, template):
 @click.argument('workflow_file', type=click.Path(exists=True))
 @click.option('--source', '-s', default='src', help='Source directory')
 @click.option('--output', '-o', default='out', help='Output directory')
-@click.option('--type', '-t', default='windows', type=click.Choice(['windows', 'posix', 'docker']), help='Execution type')
+@click.option('--type', '-t', default=DEFAULT_EXEC_TYPE, type=click.Choice(['windows', 'posix', 'docker']), help='Execution type')
 @click.option('--auto-build', is_flag=True, help='Automatically run build after generation')
 def run(workflow_file, source, output, type, auto_build):
     """Run a concore workflow"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import unittest
 import tempfile
 import shutil
+import os
 from pathlib import Path
 from click.testing import CliRunner
 from concore_cli.cli import cli
@@ -82,6 +83,23 @@ class TestConcoreCLI(unittest.TestCase):
             ])
             self.assertEqual(result.exit_code, 0)
             self.assertTrue(Path('out/src/concore.py').exists())
+
+    def test_run_command_default_type(self):
+        with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
+            result = self.runner.invoke(cli, ['init', 'test-project'])
+            self.assertEqual(result.exit_code, 0)
+
+            result = self.runner.invoke(cli, [
+                'run',
+                'test-project/workflow.graphml',
+                '--source', 'test-project/src',
+                '--output', 'out'
+            ])
+            self.assertEqual(result.exit_code, 0)
+            if os.name == 'nt':
+                self.assertTrue(Path('out/build.bat').exists())
+            else:
+                self.assertTrue(Path('out/build').exists())
 
     def test_run_command_existing_output(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):


### PR DESCRIPTION

Hi @pradeeban ,This pr fixes issue #260 
## Why this change?
`concore run` defaults to `--type windows` on all platforms. On Linux/macOS this generates Windows scripts (`.bat`) and Windows commands, so the default Quick Start fails unless users override `--type posix`.

---

## What was the problem?
- CLI default is always `windows`
- Non‑Windows users get Windows scripts by default
- Default behavior is wrong on Linux/macOS

---

## How I solved it
1. Made the default `--type` OS-aware (`windows` on Windows, `posix` otherwise)
2. Added a regression test to verify the generated build script matches the platform default

---

## Changes / Implementation
- `concore_cli/cli.py`
  - Dynamic default for `--type`
- `tests/test_cli.py`
  - New test `test_run_command_default_type`

---

## How to Test Locally
python -m pytest -v tests/test_cli.py
python -m pytest -v


---

## Evidence
- `python -m pytest -v`  
  `57 passed in 2.41s`

---

## PR Checklist
- [x] Added tests for the new behavior  
- [x] Ran full test suite locally  
- [x] No public API changes  
- [x] Backwards-compatible (Windows default unchanged)
