### PR TITLE
Add node label validation to prevent command injection (#251)

### DIFF
--- a/concore_cli/commands/validate.py
+++ b/concore_cli/commands/validate.py
@@ -84,6 +84,11 @@ def validate_workflow(workflow_file, console):
                     label = label_tag.text.strip()
                     node_labels.append(label)
                     
+                    # reject shell metacharacters to prevent command injection (#251)
+                    if re.search(r'[;&|`$\'"()\\]', label):
+                        errors.append(f"Node '{label}' contains unsafe shell characters")
+                        continue
+
                     if ':' not in label:
                         warnings.append(f"Node '{label}' missing format 'ID:filename'")
                     else:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -112,6 +112,23 @@ class TestGraphValidation(unittest.TestCase):
         self.assertIn('Validation failed', result.output)
         self.assertIn('has no filename', result.output)
 
+    def test_validate_unsafe_node_label(self):
+        content = '''
+        <graphml xmlns:y="http://www.yworks.com/xml/graphml">
+            <graph id="G" edgedefault="directed">
+                <node id="n0">
+                    <data key="d0"><y:NodeLabel>n0;rm -rf /:script.py</y:NodeLabel></data>
+                </node>
+            </graph>
+        </graphml>
+        '''
+        filepath = self.create_graph_file('injection.graphml', content)
+
+        result = self.runner.invoke(cli, ['validate', filepath])
+
+        self.assertIn('Validation failed', result.output)
+        self.assertIn('unsafe shell characters', result.output)
+
     def test_validate_valid_graph(self):
         content = '''
         <graphml xmlns:y="http://www.yworks.com/xml/graphml">


### PR DESCRIPTION
Dev branch already has [safe_name()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) validation for this. Added the same check to CLI validate so users catch bad labels earlier instead of at runtime.

Added test for shell metacharacters in node labels.

fixes #251

