### PR TITLE
check taskkill return code on Windows to detect failures

### DIFF
--- a/concore_cli/commands/stop.py
+++ b/concore_cli/commands/stop.py
@@ -56,9 +56,11 @@ def stop_all(console):
             name = proc.info.get('name', 'unknown')
             
             if sys.platform == 'win32':
-                subprocess.run(['taskkill', '/F', '/PID', str(pid)], 
-                             capture_output=True, 
-                             check=False)
+                result = subprocess.run(['taskkill', '/F', '/PID', str(pid)], 
+                                      capture_output=True, 
+                                      check=False)
+                if result.returncode != 0:
+                    raise RuntimeError(f"taskkill failed with code {result.returncode}")
             else:
                 proc.terminate()
                 proc.wait(timeout=3)


### PR DESCRIPTION
On Windows, taskkill failures (access denied, process not found, etc.) were silently ignored. The process would be reported as "successfully stopped" even when it's still running. Now we check the return code and raise an exception so the existing error handler can report the actual failure. thanks

Fixes #280