### PR TITLE
use module logger in copy_with_port_portname to avoid conflict

### DIFF
--- a/copy_with_port_portname.py
+++ b/copy_with_port_portname.py
@@ -5,12 +5,6 @@ import subprocess
 import logging
 import json
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
-)
-
 def run_specialization_script(template_script_path, output_dir, edge_params_list, python_exe, copy_script_path):
     """
     Calls the copy script to generate a specialized version of a node's script.
@@ -149,6 +143,12 @@ def create_modified_script(template_script_path, output_dir, edge_params_json_st
         sys.exit(1)
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+    
     if len(sys.argv) != 4:
         print("\nUsage: python3 copy_with_port_portname.py <TEMPLATE_SCRIPT_PATH> <OUTPUT_DIRECTORY> '<JSON_PARAMETERS>'\n")
         print("Example JSON: '[{\"port\": \"2355\", \"port_name\": \"FUNBODY_REP_1\", \"source_node_label\": \"nodeA\", \"target_node_label\": \"nodeB\"}]'")


### PR DESCRIPTION
Moved [logging.basicConfig()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from module level to the if __name__ == "__main__": block in copy_with_port_portname.py. When [mkconcore.py](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) imports copy_with_port_portname, the config was being called during import and blocking mkconcore's own basicConfig, causing the logging format to be wrong depending on import order.

Fixes #278