### PR TITLE
Fix: Reuse PairedTransmitter outside loop to prevent repeated ZMQ socket creation (#268)

### DIFF
--- a/0mq/funcall.py
+++ b/0mq/funcall.py
@@ -14,24 +14,26 @@ init_simtime_ym = "[0.0, 0.0, 0.0]"
 
 u = concore.initval(init_simtime_u)
 ym = concore2.initval(init_simtime_ym)
-while(concore2.simtime<concore.maxtime):
-    while concore.unchanged():
-        u = concore.read(concore.iport['U'],"u",init_simtime_u)
-    print(u)
-    #concore.write(concore.oport['U1'],"u",u)
-    #old2 = concore2.simtime
-    #while concore2.unchanged() or concore2.simtime <= old2:
-    #    ym = concore2.read(concore.iport['Y1'],"ym",init_simtime_ym)
-    paired_transmitter = PairedTransmitter(
-        remote_host="localhost", exposed_commands=[],  
-        remote_port=2345, listen_port=2346,)
-    paired_transmitter.start_background_sync() 
-    ym = paired_transmitter.request_with_immediate_reply(
-        "fun", timeout=10.0, params={"u": [concore.simtime]+u})
-    concore2.simtime = ym[0]
-    ym = ym[1:]
+paired_transmitter = PairedTransmitter(
+    remote_host="localhost", exposed_commands=[],  
+    remote_port=2345, listen_port=2346,)
+paired_transmitter.start_background_sync()
+try:
+    while(concore2.simtime<concore.maxtime):
+        while concore.unchanged():
+            u = concore.read(concore.iport['U'],"u",init_simtime_u)
+        print(u)
+        #concore.write(concore.oport['U1'],"u",u)
+        #old2 = concore2.simtime
+        #while concore2.unchanged() or concore2.simtime <= old2:
+        #    ym = concore2.read(concore.iport['Y1'],"ym",init_simtime_ym)
+        ym = paired_transmitter.request_with_immediate_reply(
+            "fun", timeout=10.0, params={"u": [concore.simtime]+u})
+        concore2.simtime = ym[0]
+        ym = ym[1:]
+        #print(ym)
+        concore2.write(concore.oport['Y'],"ym",ym)
+        print("funcall 0mq u="+str(u)+" ym="+str(ym)+" time="+str(concore2.simtime))
+finally:
     paired_transmitter.stop_background_sync()
-    #print(ym)
-    concore2.write(concore.oport['Y'],"ym",ym)
-    print("funcall 0mq u="+str(u)+" ym="+str(ym)+" time="+str(concore2.simtime))
 print("retry="+str(concore.retrycount))


### PR DESCRIPTION
Hey pradeeban,

Fixes #268.

In `0mq/funcall.py`, `PairedTransmitter` was being created and destroyed inside every loop iteration. This resulted in unnecessary ZMQ socket creation, extra thread overhead, and in some cases port rebinding problems due to the TIME_WAIT state.

To fix this, the transmitter initialization and background thread start are moved outside the loop so they are created only once. A `try/finally` block is also added to ensure the transmitter is properly cleaned up after the loop finishes.

This improves performance and avoids potential socket exhaustion while keeping the existing behavior unchanged.