### PR TITLE
chore: upgrade FRI Dockerfile from Python 3.6 to 3.10 (fixes #270)

### DIFF
--- a/fri/Dockerfile
+++ b/fri/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.10-slim
 
 RUN apt-get update && apt-get install -y ca-certificates \
     && update-ca-certificates \


### PR DESCRIPTION
Hey pradeeban,

Fixes #270.

This PR updates the FRI Dockerfile to use Python 3.10 instead of Python 3.6.

Python 3.6 reached end-of-life in December 2021 and no longer receives security updates. Continuing to use it may expose the container to unpatched vulnerabilities. Also, the FRI README already specifies Python 3.10, so the Dockerfile and documentation were inconsistent.

The base image is updated as follows:

FROM python:3.6-slim  
→ FROM python:3.10-slim

This change aligns the Dockerfile with the documentation, uses a supported Python version, and improves long-term maintainability.

The scope of this PR is intentionally small:
- only a single-line change in the Dockerfile
- no changes to concore-lite
- no changes to the Verilog implementation
- no changes to application logic

Tested locally by building the Docker image:
`docker build -t fri-test ./fri`

The build completed successfully and all stages passed. Existing dependencies such as Flask, gunicorn (20.1.0), flask-cors, jupyterlab, and PyGithub work as expected.
Fixes #270
<img width="1234" height="1079" alt="image" src="https://github.com/user-attachments/assets/4cecd50e-782f-4751-bdd0-16a058ab62c8" />
