### PR TITLE
security: prevent API key leakage in wrapper script logs (fixes #263)

### DIFF
--- a/demo/cwrap.py
+++ b/demo/cwrap.py
@@ -58,7 +58,6 @@ except:
     except:
         init_simtime_ym = "[0.0, 0.0, 0.0]"
 
-print(apikey)
 print(yuyu)
 print(name1+'='+init_simtime_u)
 print(name2+'='+init_simtime_ym)
@@ -83,7 +82,7 @@ while(concore.simtime<concore.maxtime):
         u = concore.read(1,name1,init_simtime_u)
     f = {'file1': open(concore.inpath+'1/'+name1, 'rb')}
     print("CW: before post u="+str(u))
-    print('http://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2)
+    print('http://www.controlcore.org/pm/'+yuyu+'<APIKEY_HIDDEN>'+'&fetch='+name2)
     r = requests.post('http://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2, files=f,timeout=timeout_max)
     if r.status_code!=200:
         print("bad POST request "+str(r.status_code))

--- a/demo/pwrap.py
+++ b/demo/pwrap.py
@@ -61,7 +61,6 @@ except:
     except:
         init_simtime_ym = "[0.0, 0.0, 0.0]"
 
-print(apikey)
 print(yuyu)
 print(name1+'='+init_simtime_u)
 print(name2+'='+init_simtime_ym)

--- a/ratc/cwrap.py
+++ b/ratc/cwrap.py
@@ -58,7 +58,6 @@ except:
     except:
         init_simtime_ym = "[0.0, 0.0, 0.0]"
 
-print(apikey)
 print(yuyu)
 print(name1+'='+init_simtime_u)
 print(name2+'='+init_simtime_ym)
@@ -83,7 +82,7 @@ while(concore.simtime<concore.maxtime):
         u = concore.read(1,name1,init_simtime_u)
     f = {'file1': open(concore.inpath+'1/'+name1, 'rb')}
     print("CW: before post u="+str(u))
-    print('http://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2)
+    print('http://www.controlcore.org/pm/'+yuyu+'<APIKEY_HIDDEN>'+'&fetch='+name2)
     r = requests.post('http://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2, files=f,timeout=timeout_max)
     if r.status_code!=200:
         print("bad POST request "+str(r.status_code))

--- a/ratc/pwrap.py
+++ b/ratc/pwrap.py
@@ -61,7 +61,6 @@ except:
     except:
         init_simtime_ym = "[0.0, 0.0, 0.0]"
 
-print(apikey)
 print(yuyu)
 print(name1+'='+init_simtime_u)
 print(name2+'='+init_simtime_ym)


### PR DESCRIPTION
Hey pradeeban,

Fixes #263.

This PR removes a case where API keys could be printed to stdout in some wrapper scripts.

Previously the scripts contained `print(apikey)`. Since stdout is captured in `concoreout.txt`, this meant the API key could end up stored in plaintext log files.

The `print(apikey)` statement has been removed from the following files:
- demo/cwrap.py
- demo/pwrap.py
- ratc/cwrap.py
- ratc/pwrap.py

In addition, the debug URL print in `demo/cwrap.py` and `ratc/cwrap.py` is sanitized so it shows `<APIKEY_HIDDEN>` instead of the real key.

There are no logic changes. The API key is still read and used normally for HTTP requests, it is just no longer printed.

Scope of this change is intentionally small:
- about 6 lines modified across 4 files
- no changes to concore-lite
- no changes to the Verilog code
- no behavior changes outside removing the key from logs

Testing:
- All modified files pass Python syntax checks
- Full test suite passes (57/57 tests)
- Verified that `print(apikey)` no longer appears anywhere in the repository

<img width="1223" height="1079" alt="image" src="https://github.com/user-attachments/assets/e3e033a2-f65b-4e51-97f1-1226d47a18d8" />
