### PR TITLE
security: fix path traversal vulnerability in FRI download endpoint (fixes #262)

### DIFF
--- a/fri/server/main.py
+++ b/fri/server/main.py
@@ -362,7 +362,7 @@ def download(dir):
 
     try:
         return send_from_directory(directory_name, safe_path, as_attachment=True)
-    except:
+    except Exception:
         resp = jsonify({'message': 'file not found'})
         resp.status_code = 400
         return resp


### PR DESCRIPTION
Hey pradeeban,

Fixes #262.

This PR adds validation in the FRI server `/download` endpoint to prevent path traversal.

Previously the `fetch` parameter was passed directly to `send_from_directory`. Because it was not validated, it was possible to request files outside the intended directory. For example:

/download/test?fetchDir=src&fetch=../../../../etc/passwd

This could potentially expose arbitrary files on the server.

To fix this, the requested file path is now validated before it is used. The path is normalized with `os.path.normpath`, absolute paths are rejected, and any path containing `..` traversal components is blocked. A final check also ensures the resolved path stays within the allowed directory.

Invalid requests now return proper HTTP error responses.

Changes in this PR:
- `fri/server/main.py` – added validation for the `fetch` parameter and path checks

The scope of this change is intentionally small:
- single file modification
- no changes to concore-lite
- no changes to Verilog code
- valid download requests continue to work as before

Tested locally:
- normal file downloads work correctly
- missing `fetch` parameter returns 400
- traversal attempts like `../../etc/passwd` return 400
- URL-encoded traversal (`..%2F..%2Fetc%2Fpasswd`) is blocked
- absolute paths such as `/etc/passwd` or `C:\Windows\...` are rejected
- backslash traversal (`..\..\etc\passwd`) is also blocked

<img width="1159" height="1073" alt="image" src="https://github.com/user-attachments/assets/b94c0d84-9271-467f-923c-dbc73af4c288" />
