### PR TITLE
Update python Dockerfile to be more consistent

### DIFF
--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -1,10 +1,9 @@
 FROM jupyter/base-notebook
  
 USER root
-RUN apt-get update
-RUN apt-get install -y build-essential g++ libgl1-mesa-glx libx11-6
-RUN conda install matplotlib scipy  
-RUN pip install cvxopt 
+RUN apt-get update && apt-get install -y build-essential g++ libgl1-mesa-glx libx11-6
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 COPY . /src 
 WORKDIR /src
 


### PR DESCRIPTION
matplotlib scipy  cvxopt already exists in requirements.txt and doesn't need to be installed so separately. 

This change will also install some important packages that are required as of right now to build the Docker image.

@pradeeban please have a look. This fixes #317 .