### PR TITLE
Use HTTPS for API calls

### DIFF
--- a/tools/cwrap.py
+++ b/tools/cwrap.py
@@ -97,8 +97,8 @@ while(concore.simtime<concore.maxtime):
     with open(concore.inpath+'1/'+name1, 'rb') as f1:
         f = {'file1': f1}
         logging.debug(f"CW: before post u={u}")
-        logging.debug(f'http://www.controlcore.org/pm/{yuyu}{apikey}&fetch={name2}')
-        r = requests.post('http://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2, files=f,timeout=timeout_max)
+        logging.debug(f'https://www.controlcore.org/pm/{yuyu}{apikey}&fetch={name2}')
+        r = requests.post('https://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2, files=f,timeout=timeout_max)
     if r.status_code!=200:
         logging.error(f"bad POST request {r.status_code}")
         quit()
@@ -117,7 +117,7 @@ while(concore.simtime<concore.maxtime):
         with open(concore.inpath+'1/'+name1, 'rb') as f1:
             f = {'file1': f1}
             try:
-                r = requests.post('http://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2, files=f,timeout=timeout_max)
+                r = requests.post('https://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2, files=f,timeout=timeout_max)
             except Exception:
                 logging.error("CW: bad request")
         timeout_count += 1

--- a/tools/pwrap.py
+++ b/tools/pwrap.py
@@ -83,7 +83,7 @@ oldt = 0
 #initfiles = {'file1': open('./u', 'rb'), 'file2': open(concore.inpath+'1/ym', 'rb')}
 initfiles = {'file1': open('./'+name1, 'rb'), 'file2': open(concore.inpath+'1/'+name2, 'rb')}
 # POST Request to /init with u as file1 and ym as file2
-r = requests.post('http://www.controlcore.org/init/'+yuyu+apikey, files=initfiles)
+r = requests.post('https://www.controlcore.org/init/'+yuyu+apikey, files=initfiles)
 
 
 while(concore.simtime<concore.maxtime):
@@ -92,7 +92,7 @@ while(concore.simtime<concore.maxtime):
         ym = concore.read(1,name2,init_simtime_ym)
     f = {'file1': open(concore.inpath+'1/'+name2, 'rb')}
     logging.debug(f"PW: before post ym={ym}")
-    r = requests.post('http://www.controlcore.org/ctl/'+yuyu+apikey+'&fetch='+name1, files=f,timeout=timeout_max)
+    r = requests.post('https://www.controlcore.org/ctl/'+yuyu+apikey+'&fetch='+name1, files=f,timeout=timeout_max)
     if r.status_code!=200:
         logging.error(f"bad POST request {r.status_code}")
         quit()
@@ -110,7 +110,7 @@ while(concore.simtime<concore.maxtime):
         logging.debug(f"PW waiting status={r.status_code} content={r.content.decode('utf-8')} t={t}")
         f = {'file1': open(concore.inpath+'1/'+name2, 'rb')}
         try:
-            r = requests.post('http://www.controlcore.org/ctl/'+yuyu+apikey+'&fetch='+name1, files=f,timeout=timeout_max)
+            r = requests.post('https://www.controlcore.org/ctl/'+yuyu+apikey+'&fetch='+name1, files=f,timeout=timeout_max)
         except:
             logging.error("PW: bad requests")
         timeout_count += 1


### PR DESCRIPTION
Replaced all http calls with https in tools/cwrap.py and tools/pwrap.py to stop leaking API keys. Server supports TLS so this is a drop-in fix.

Fixes https://github.com/ControlCore-Project/concore/issues/309