### PR TITLE
Optimize matlab dockerfile to remove unnecessary image bloating

### DIFF
--- a/Dockerfile.sh
+++ b/Dockerfile.sh
@@ -13,9 +13,8 @@ ARG MATLAB_RUNTIME_SHA256="b821022690804e498d2e5ad814dccb64aab17c5e4bc10a1e2a124
 ENV MATLAB_RUNTIME_SHA256=${MATLAB_RUNTIME_SHA256}
 
 RUN wget https://ssd.mathworks.com/supportfiles/downloads/R2021a/Release/1/deployment_files/installer/complete/glnxa64/MATLAB_Runtime_R2021a_Update_1_glnxa64.zip \
-    && echo "${MATLAB_RUNTIME_SHA256}  MATLAB_Runtime_R2021a_Update_1_glnxa64.zip" | sha256sum -c -
-
-RUN unzip MATLAB_Runtime_R2021a_Update_1_glnxa64.zip \
+    && echo "${MATLAB_RUNTIME_SHA256}  MATLAB_Runtime_R2021a_Update_1_glnxa64.zip" | sha256sum -c - \
+    && unzip MATLAB_Runtime_R2021a_Update_1_glnxa64.zip \
     && ./install -destinationFolder /opt/mcr -agreeToLicense yes -mode silent \
     && cd / \
     && rm -rf mcr-install


### PR DESCRIPTION
The solution is pretty simple: chain the download, extraction, installation, and deletion steps into a single RUN instruction using the && operator in the matlab dockerfile

this will make sure that temporary .zip file and the installation dir. are completely removed before docker starts to commit the layer. This fixes #325 .