### PR TITLE
optimize Dockerfile.v by clearing apt cache

### DIFF
--- a/Dockerfile.v
+++ b/Dockerfile.v
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        iverilog
+        iverilog && rm -rf /var/lib/apt/lists/*
 
 COPY . /src
 WORKDIR /src


### PR DESCRIPTION
this make sures that Ubuntu package indices are not unnecessarily saved into the Docker image layer, reducing the image size of the final build.
This fixes #330 .