### PR TITLE
advance simtime after write in C++ and Verilog

### DIFF
--- a/concore.hpp
+++ b/concore.hpp
@@ -494,6 +494,7 @@ private:
                     outfile<<val[i]<<',';
                 outfile<<val[val.size()-1]<<']';
                 outfile.close();
+                simtime += delta;
                 }
             else{
                 throw 505;
@@ -549,6 +550,7 @@ private:
                 outfile<<val[val.size()-1]<<']';
                 std::string result = outfile.str();
                 std::strncpy(sharedData_create, result.c_str(), 256 - 1);
+                simtime += delta;
                 }
             else{
                 throw 505;

--- a/concore.v
+++ b/concore.v
@@ -296,6 +296,7 @@ module concore;
       end
      $fdisplay(fout,"]");
      $fclose(fout);
+     simtime = simtime + delta;
     end
   endtask
 


### PR DESCRIPTION

[write_FM()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [write_SM()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [concore.hpp](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prepend [simtime + delta](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the data but never actually advance simtime after the write completes. Same bug in concore.v's writedata task. This breaks downstream readers that use simtime to detect fresh data since the timestamp never changes across writes in a loop

Python version does [simtime += delta](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) after write (line 421), so copying that behavior.

Closes #337