### PR TITLE
Optimize Dockerfile for python environment

### DIFF
--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -1,9 +1,8 @@
-FROM jupyter/base-notebook
+FROM python:3.10-slim
  
-USER root
-RUN apt-get update && apt-get install -y build-essential g++ libgl1-mesa-glx libx11-6
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-COPY . /src 
 WORKDIR /src
+RUN apt-get update && apt-get install -y build-essential g++ libgl1-mesa-glx libx11-6 && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
 


### PR DESCRIPTION
Changes I have made:
- Replaced jupyter/base-notebook (about 2 G.B.) with the official python:3.10-slim image (about 120 mb).
- Optimized layer Caching by changing the sequence, re-installation won't happen unnecessarily unless requirements.txt is modified.
- used apt & pip cleanup to prevent the cache from being permanently backed into the image.
- removed USER root declaration, as python slim images run as root by default, keeping the execution clean.

This fixes #334