### PR TITLE
fix simtime update in write_FM and write_SM functions

### DIFF
--- a/concore.hpp
+++ b/concore.hpp
@@ -451,6 +451,7 @@ private:
                     outfile<<val[i]<<',';
                 outfile<<val[val.size()-1]<<']';
                 outfile.close();
+                simtime += delta;
                 }
             else{
                 throw 505;
@@ -506,6 +507,7 @@ private:
                 outfile<<val[val.size()-1]<<']';
                 std::string result = outfile.str();
                 std::strncpy(sharedData_create, result.c_str(), 256 - 1);
+                simtime += delta;
                 }
             else{
                 throw 505;


### PR DESCRIPTION
While porting behavior from Python to C++, I found that [write_FM] and [write_SM] were writing timestamps into the output but never advancing the [simtime] member. That left simulations stuck at the same time across steps.

This change makes the C++ functions increment [simtime] by [delta] immediately after a successful write (vector payloads only, matching the Python implementation).