### PR TITLE
fix simtime not advancing in MATLAB write function

### DIFF
--- a/concore_write.m
+++ b/concore_write.m
@@ -5,6 +5,7 @@ function concore_write(port, name, val, delta)
          outstr = cat(2,"[",num2str(concore.simtime+delta),num2str(val,",%e"),"]");
          fprintf(output1,'%s',outstr);
          fclose(output1);
+         concore.simtime = concore.simtime + delta;
      catch exc
          disp(['skipping ' concore.outpath num2str(port) '/' name]);
      end


### PR DESCRIPTION
The MATLAB write function was including [simtime+delta] in the output but never updating the global [concore.simtime] variable, leaving simulations frozen at the initial time step. This adds the missing update after successful writes, matching the Python and recently-fixed C++ implementations.