### PR TITLE
fix java params to use semicolon separator

### DIFF
--- a/concoredocker.java
+++ b/concoredocker.java
@@ -36,7 +36,7 @@ public class concoredocker {
             }
             if (!sparams.equals("{")) {
                 System.out.println("converting sparams: " + sparams);
-                sparams = "{'" + sparams.replaceAll(",", ",'").replaceAll("=", "':").replaceAll(" ", "") + "}";
+                sparams = "{'" + sparams.replaceAll(";", ",'").replaceAll("=", "':").replaceAll(" ", "") + "}";
                 System.out.println("converted sparams: " + sparams);
             }
             try {


### PR DESCRIPTION
Python parse_params splits on `;` now but Java still used `,`

Changed line 39 to match Python behavior

Fixes #355