### PR TITLE
add missing deps to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "concore"
 version = "1.0.0"
 description = "Concore workflow management CLI"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 dependencies = [
     "click>=8.0.0",
@@ -15,6 +15,10 @@ dependencies = [
     "beautifulsoup4>=4.9.0",
     "lxml>=4.6.0",
     "psutil>=5.8.0",
+    "numpy>=1.19.0",
+    "pyzmq>=22.0.0",
+    "scipy>=1.5.0",
+    "matplotlib>=3.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION

[setup.py](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) had numpy/pyzmq/scipy/matplotlib but [pyproject.toml](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) didn't. pip install breaks without them

also fixed python version to match [setup.py](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html),

fixes #35