### PR TITLE
fix: guard against empty string crash in parser() and bounds check in…

### DIFF
--- a/concore.hpp
+++ b/concore.hpp
@@ -240,6 +240,7 @@ private:
      */
     vector<double> parser(string f){
         vector<double> temp;
+        if(f.empty()) return temp;
         string value = "";
     
         //Changing last bracket to comma to use comma as a delimiter
@@ -330,6 +331,10 @@ private:
         s += ins;
 
         vector<double> inval = parser(ins);
+        if(inval.empty())
+            inval = parser(initstr);
+        if(inval.empty())
+            return inval;
         simtime = simtime > inval[0] ? simtime : inval[0];
 
         //returning a string with data excluding simtime
@@ -389,6 +394,10 @@ private:
         s += ins;
 
         vector<double> inval = parser(ins);
+        if(inval.empty())
+            inval = parser(initstr);
+        if(inval.empty())
+            return inval;
         simtime = simtime > inval[0] ? simtime : inval[0];
 
         //returning a string with data excluding simtime


### PR DESCRIPTION
Fixes #339

parser() crashes on empty strings (length-1 wraps to SIZE_MAX).
read_FM/read_SM don't check if parser returns empty before accessing [0]

Added empty check in parser, bounds checks in both read functions.