### PR TITLE
security: harden contribute.py with token validation, error sanitization, and retry/backoff (fixes #288)

### DIFF
--- a/contribute.py
+++ b/contribute.py
@@ -5,12 +5,12 @@ import os,sys,platform,base64,time,re
 # Initializing the Variables
 BOT_TOKEN = os.environ.get('CONCORE_BOT_TOKEN', '')
 
-# Fix 1: Fail fast if token is missing
+# Fail fast if token is missing
 if not BOT_TOKEN:
     print("Error: CONCORE_BOT_TOKEN environment variable is not set.")
     sys.exit(1)
 
-# Fix 2: Token format validation
+# Token format validation
 token_pattern = r"^((ghp_|github_pat_|ghs_)[A-Za-z0-9_]{20,}|[0-9a-fA-F]{40})$"
 if not re.match(token_pattern, BOT_TOKEN):
     print("Error: Invalid GitHub token format.")
@@ -34,7 +34,7 @@ def checkInputValidity():
         print("Directory does not Exists.Invalid Path")
         exit(1)
 
-# Fix 5: Retry + backoff wrapper for PyGithub operations
+# Retry + backoff wrapper for PyGithub operations
 def with_retry(operation, retries=3):
     """Retry wrapper for PyGithub operations with exponential backoff."""
     for attempt in range(retries):
@@ -49,7 +49,7 @@ def with_retry(operation, retries=3):
     print("Error: GitHub API request failed after retries.")
     sys.exit(1)
 
-# Fix 4: Correct PR URL (singular 'pull' not 'pulls')
+# Correct PR URL (singular 'pull' not 'pulls')
 def printPR(pr):
     print(f'Check your example here https://github.com/{UPSTREAM_ACCOUNT}/{REPO_NAME}/pull/{pr.number}',end="")
 
@@ -131,8 +131,6 @@ def remove_prefix(text, prefix):
         return text[len(prefix):]
     return text
 
-
-# Fix 9: Removed unused decode_token() function
 
 # check if directory path is Valid
 checkInputValidity()


### PR DESCRIPTION
Hey pradeeban,

Fixes #288.

This PR improves the security and reliability of `contribute.py`, mainly around how it handles GitHub API authentication and errors.

Previously the script would continue running even if the token was empty, which could lead to confusing failures later. Now the script checks for `CONCORE_BOT_TOKEN` at startup and exits with a clear error message if it is missing.

A simple format check is also added for the token using regex. It supports common GitHub token formats such as `ghp_`, `github_pat_`, `ghs_`, and the classic 40-character hex tokens. This helps catch obvious configuration mistakes early.

Some changes were also made to avoid accidental token exposure. Unsafe prints were removed and exception handling avoids logging the token value.

Other fixes and improvements:
- Corrected PR URL construction (`pull/{pr.number}` instead of `pulls/{pr.number}`)
- Added a small retry wrapper (`with_retry`) with exponential backoff for GitHub API calls to handle rate limits and temporary server errors
- Replaced incorrect `requests.exceptions.*` handling with `github.GithubException`, which is what PyGithub actually raises
- Fixed use of `e.response.status_code` to the correct `e.status` attribute
- Removed unused `decode_token()` function
- Removed unused `requests` import
- Fixed a few spelling mistakes in messages

These changes are limited to a single file: `contribute.py`.  
No other modules were modified, and existing workflows should continue to work as before.

Testing done locally:
- Script exits with code 1 when `CONCORE_BOT_TOKEN` is missing
- Script exits with code 1 when token format is invalid
- Classic 40-character tokens pass validation
- `github.GithubException` is caught correctly (e.g., 401)
- Token values never appear in console output
- PR URLs now use the correct `/pull/` endpoint