### PR TITLE
fix: align Windows destroy.bat behavior with bash destroy script (fixes #342)

### DIFF
--- a/destroy.bat
+++ b/destroy.bat
@@ -1,3 +1,25 @@
 @echo off
-if exist "%1\stop.bat" (rmdir /s/q %1) else (echo "%1 is not a concore study")
+
+if not exist "%1" (
+    echo "%1 does not exist"
+    exit /b 1
+)
+
+if not exist "%1\stop.bat" (
+    echo "%1 is not a concore study"
+    exit /b 1
+)
+
+echo Stopping study...
+call "%1\stop.bat"
+
+if exist "%1\clear.bat" (
+    echo Clearing study...
+    call "%1\clear.bat"
+)
+
+echo Removing study directory...
+rmdir /s /q "%1"
+
+echo Done.
 


### PR DESCRIPTION
Hi pradeeban Sir,

Fixes #342.

This PR updates `destroy.bat` so its behavior matches the bash `destroy` script.

Previously `destroy.bat` only checked whether `stop.bat` existed and then immediately deleted the study directory. It did not actually run `stop.bat` or `clear.bat`. Because of this, Docker containers or background processes could remain running, and volumes or files could be left behind.

This change makes the Windows script follow the same order as the bash version.

Changes in this PR:
- Added a check to make sure the directory exists
- Added an explicit call to `stop.bat` before deletion
- Added a conditional call to `clear.bat` (if the file exists)
- After cleanup, the directory is removed using `rmdir /s /q`
- Existing validation logic for rejecting non-study directories is kept
- Batch files are executed using proper `call` semantics

The result is that Windows now follows the same flow as bash:

stop → clear → delete

Scope:
- Single file modified: `destroy.bat`
- No changes to the bash destroy script
- No changes to any other files

Testing done locally on Windows:

1. Non-existent directory → error message, exit code 1  
2. Directory without `stop.bat` (not a concore study) → error message, exit code 1  
3. Valid study with `stop.bat` and `clear.bat` → stop runs → clear runs → directory removed  
4. Valid study with only `stop.bat` → stop runs → directory removed (clear skipped)

All tests passed.