### PR TITLE
maintenance: update oldeditgraph DHGWorkflow link to archived repository URL (fixes #346)

### DIFF
--- a/oldeditgraph
+++ b/oldeditgraph
@@ -2,12 +2,12 @@
 which open
 if [ $? == 0 ] 
 then
-   open https://pradeeban.github.io/DHGWorkflow/
+   open https://kathiravelulab.github.io/DHGWorkflow/
 else
    which xdg-open
    if [ $? == 0 ] 
    then
-      xdg-open https://pradeeban.github.io/DHGWorkflow/
+      xdg-open https://kathiravelulab.github.io/DHGWorkflow/
    else
       echo "unable to open browser for DHGWorkflow"
    fi


### PR DESCRIPTION
Hey pradeeban,

This PR updates the DHGWorkflow URL referenced in `oldeditgraph`.

The script previously pointed to:
https://pradeeban.github.io/DHGWorkflow/

As discussed, that repository has been archived and is now hosted at:
https://kathiravelulab.github.io/DHGWorkflow/
https://github.com/KathiraveluLab/DHGWorkflow

The repository is archived (read-only) but still available, so the script should point to the correct location.

Changes in this PR:
- Updated the GitHub Pages URL in `oldeditgraph` (2 occurrences)
- No changes to the script logic

Scope of this change:
- Single file updated: `oldeditgraph`
- No removal of `oldeditgraph`
- No deprecation changes
- No changes to `editgraph`
- No changes to `concore-lite`
- No Verilog changes

Result:
- `oldeditgraph` now links to the correct archived DHGWorkflow editor
- Avoids confusion caused by the outdated link

Related issues:
- #346
- #374