### PR TITLE
security: sanitize fetch parameter in /download endpoint using secure_filename (fixes #358)

### DIFF
--- a/fri/server/main.py
+++ b/fri/server/main.py
@@ -433,6 +433,11 @@ def download(dir):
     if not download_file:
         abort(400, description="Missing file parameter")
 
+    download_file = secure_filename(download_file)
+
+    if download_file == "":
+        abort(400, description="Invalid filename")
+
     # Normalize the requested file path
     safe_path = os.path.normpath(download_file)
 


### PR DESCRIPTION
Hello pradeeban Sir,

Fixes #358.

This PR improves validation of the `fetch` parameter in the `/download` endpoint.

Previously, `dir` and `fetchDir` were sanitized, but the `fetch` value (used as the filename) was passed directly to `send_from_directory()` without sanitization. This meant a request like:

fetch=../../etc/passwd

could attempt directory traversal.

This change applies `secure_filename()` to the requested filename before it is used. It also adds a small check to ensure the filename is not empty after sanitization.

Changes in this PR:
- Applied `secure_filename()` to `download_file`
- Added validation to reject missing or empty filenames
- Kept the existing endpoint logic and security checks unchanged

Security impact:
- Prevents directory traversal attempts through the `fetch` parameter
- Restricts filenames to safe patterns (e.g. `../../etc/passwd` becomes `etc_passwd`)
- Blocks empty or invalid filenames with a 400 response

Scope:
- Single file modified: `fri/server/main.py`
- No changes to `concore-lite`
- No changes to Verilog code
- No behavior change for valid requests

Testing done locally:
- Normal downloads such as `fetch=example.txt` still work
- Traversal attempts like `fetch=../../etc/passwd` are sanitized
- Empty or invalid filenames return HTTP 400
- No regressions observed in directory handling

Please review. Thank you.
<img width="1248" height="1079" alt="image" src="https://github.com/user-attachments/assets/96be2262-472c-41c8-83bc-60cdec49df68" />
