### PR TITLE
security: protect /openJupyter endpoint with API key and process control (fixes #361)

### DIFF
--- a/fri/server/main.py
+++ b/fri/server/main.py
@@ -6,9 +6,14 @@ import subprocess
 from subprocess import call,check_output
 from pathlib import Path
 import json
+import logging
 import platform
 import re
+import secrets
+import threading
 from flask_cors import CORS, cross_origin
+
+logger = logging.getLogger(__name__)
 
 # Input validation pattern for safe names (alphanumeric, dash, underscore, slash, dot, space)
 SAFE_INPUT_PATTERN = re.compile(r'^[a-zA-Z0-9_\-/. ]+$')
@@ -91,12 +96,13 @@ def require_api_key():
     """Require a valid API key via X-API-KEY header."""
     if not API_KEY:
         abort(500, description="Server not configured with API key")
-    provided = request.headers.get("X-API-KEY")
-    if provided != API_KEY:
+    provided = request.headers.get("X-API-KEY") or ""
+    if not secrets.compare_digest(provided, API_KEY):
         abort(403, description="Unauthorized")
 
 # Track single Jupyter process to prevent multiple concurrent launches
 jupyter_process = None
+jupyter_lock = threading.Lock()
 
 
 app = Flask(__name__)
@@ -554,20 +560,22 @@ def openJupyter():
 
     require_api_key()
 
-    if jupyter_process and jupyter_process.poll() is None:
-        return jsonify({"message": "Jupyter already running"}), 409
+    with jupyter_lock:
+        if jupyter_process and jupyter_process.poll() is None:
+            return jsonify({"message": "Jupyter already running"}), 409
 
-    try:
-        jupyter_process = subprocess.Popen(
-            ['jupyter', 'lab', '--no-browser'],
-            shell=False,
-            cwd=concore_path,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL
-        )
-        return jsonify({"message": "Jupyter Lab started"}), 200
-    except Exception:
-        return jsonify({"error": "Failed to start Jupyter"}), 500
+        try:
+            jupyter_process = subprocess.Popen(
+                ['jupyter', 'lab', '--no-browser'],
+                shell=False,
+                cwd=concore_path,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL
+            )
+            return jsonify({"message": "Jupyter Lab started"}), 200
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            logger.error("Failed to start Jupyter: %s", e)
+            return jsonify({"error": "Failed to start Jupyter"}), 500
 
 
 @app.route('/stopJupyter/', methods=['POST'])
@@ -576,13 +584,22 @@ def stopJupyter():
 
     require_api_key()
 
-    if not jupyter_process or jupyter_process.poll() is not None:
-        return jsonify({"message": "No running Jupyter instance"}), 404
+    with jupyter_lock:
+        if not jupyter_process or jupyter_process.poll() is not None:
+            return jsonify({"message": "No running Jupyter instance"}), 404
 
-    jupyter_process.terminate()
-    jupyter_process = None
+        try:
+            jupyter_process.terminate()
+            # Wait for Jupyter to terminate gracefully
+            jupyter_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            # Force kill if it did not exit in time
+            jupyter_process.kill()
+            jupyter_process.wait(timeout=5)
+        finally:
+            jupyter_process = None
 
-    return jsonify({"message": "Jupyter stopped"}), 200
+        return jsonify({"message": "Jupyter stopped"}), 200
 
 
 if __name__ == "__main__":

--- a/tests/test_openjupyter_security.py
+++ b/tests/test_openjupyter_security.py
@@ -109,7 +109,7 @@ class TestOpenJupyterProcess:
         data = resp2.get_json()
         assert data["message"] == "Jupyter already running"
 
-    @patch("fri.server.main.subprocess.Popen", side_effect=Exception("fail"))
+    @patch("fri.server.main.subprocess.Popen", side_effect=OSError("fail"))
     def test_popen_failure_returns_500(self, mock_popen, client):
         """If Popen raises, return 500."""
         resp = client.post(
@@ -153,3 +153,4 @@ class TestStopJupyter:
         data = resp.get_json()
         assert data["message"] == "Jupyter stopped"
         mock_proc.terminate.assert_called_once()
+        mock_proc.wait.assert_called()


### PR DESCRIPTION
Hello @pradeeban Sir
This PR resolves Issue #361, a critical security vulnerability where the [/openJupyter](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) endpoint allowed unauthenticated spawning of Jupyter Lab processes.

**Previously:**
No authentication
No rate limiting
Unlimited process spawning
No process tracking
Full remote code execution exposure

**Changes Made**
Added API key authentication (X-API-KEY header)
Introduced environment variable CONCORE_API_KEY
Prevented multiple concurrent Jupyter launches
Added process tracking
Suppressed stdout/stderr exposure
Added optional [/stopJupyter](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) endpoint for cleanup

**Security Impact**
Eliminates unauthenticated RCE vector
Prevents resource exhaustion
Restricts access to authorized clients only
Improves process lifecycle control

**Scope**
Single file modification (fri/server/main.py)
New test file: tests/test_openjupyter_security.py (9 tests)
No changes to concore-lite
No Verilog changes
Minimal architectural impact

**Configuration Required**
Server must define:
`CONCORE_API_KEY=<secure_random_string>`
Clients must provide:
`X-API-KEY header`

**Testing**

| Test Case                              | Expected | Result |
|----------------------------------------|----------|--------|
| Unauthorized request (no header)      | 403      | PASSED |
| Wrong API key                         | 403      | PASSED |
| Server without key configured         | 500      | PASSED |
| Authorized request starts Jupyter     | 200      | PASSED |
| Duplicate launch while running        | 409      | PASSED |
| Popen failure                         | 500      | PASSED |
| Stop without auth                     | 403      | PASSED |
| Stop with no running process          | 404      | PASSED |
| Stop running process                  | 200      | PASSED |


<img width="1254" height="994" alt="Screenshot 2026-02-18 173936" src="https://github.com/user-attachments/assets/7f05a374-af55-4f54-98ae-23819284ec13" />

