### PR TITLE
Fix mkconcore path handling for nested output directories

### DIFF
--- a/mkconcore.py
+++ b/mkconcore.py
@@ -142,7 +142,8 @@ if len(sys.argv) < 4:
     print(" type must be posix (macos or ubuntu), windows, or docker")
     sys.exit(1)
 
-GRAPHML_FILE = sys.argv[1]
+ORIGINAL_CWD = os.getcwd()
+GRAPHML_FILE = os.path.abspath(sys.argv[1])
 TRIMMED_LOGS = True
 CONCOREPATH = _resolve_concore_path()
 CPPWIN    = os.environ.get("CONCORE_CPPWIN", "g++")          #Windows C++  6/22/21
@@ -197,8 +198,8 @@ if os.path.exists(CONCOREPATH+"/concore.tools"):
     OCTAVEWIN = _tools.get("OCTAVEWIN", OCTAVEWIN)
 
 prefixedgenode = ""
-sourcedir = sys.argv[2]
-outdir = sys.argv[3]
+sourcedir = os.path.abspath(sys.argv[2])
+outdir = os.path.abspath(sys.argv[3])
 
 # Validate outdir argument (allow full paths)
 safe_name(outdir, "Output directory argument", allow_path=True)
@@ -208,7 +209,8 @@ if not os.path.isdir(sourcedir):
     quit()
 
 if len(sys.argv) == 4:
-    prefixedgenode = outdir+"_" #nodes and edges prefixed with outdir_ only in case no type specified 3/24/21
+    # Use only the output directory name in generated prefixes.
+    prefixedgenode = os.path.basename(os.path.normpath(outdir)) + "_"
     concoretype = "docker"
 else:
     concoretype = sys.argv[4]
@@ -227,7 +229,7 @@ if os.path.exists(outdir):
     logging.error(f"if intended, Remove/Rename {outdir} first")
     quit()
 
-os.mkdir(outdir)
+os.makedirs(outdir)
 os.chdir(outdir)
 if concoretype == "windows":
     fbuild = open("build.bat","w")
@@ -256,7 +258,7 @@ def cleanup_script_files():
 atexit.register(cleanup_script_files)
 
 os.mkdir("src")
-os.chdir("..")
+os.chdir(ORIGINAL_CWD)
 
 logging.info(f"mkconcore {MKCONCORE_VER}")
 logging.info(f"Concore path: {CONCOREPATH}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,6 +114,21 @@ class TestConcoreCLI(unittest.TestCase):
             else:
                 self.assertTrue(Path('out/build').exists())
 
+    def test_run_command_nested_output_path(self):
+        with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
+            result = self.runner.invoke(cli, ['init', 'test-project'])
+            self.assertEqual(result.exit_code, 0)
+
+            result = self.runner.invoke(cli, [
+                'run',
+                'test-project/workflow.graphml',
+                '--source', 'test-project/src',
+                '--output', 'build/out',
+                '--type', 'posix'
+            ])
+            self.assertEqual(result.exit_code, 0)
+            self.assertTrue(Path('build/out/src/concore.py').exists())
+
     def test_run_command_subdir_source(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ['init', 'test-project'])


### PR DESCRIPTION
Hi @pradeeban ,
This PR fixes issue #381 that caused failures when using nested output paths (for example, `build/out`) and relative workflow/source paths.

### **Approach**
I used a minimal, backward-compatible path normalization approach:
- Convert CLI path inputs to absolute paths early.
- Keep directory changes local and always restore the original cwd.
- Make output directory creation robust for nested paths.
- Add one focused regression test that reproduces the reported scenario.

### **Summary of changes**

- Resolve `workflow`, `source`, and `output` arguments to absolute paths at startup.
- Store and restore the original working directory, instead of using `os.chdir("..")`.
- Replace `os.mkdir(outdir)` with `os.makedirs(outdir)` so nested output directories are created correctly.
- When no type is provided, generate the default prefix from the output directory name (`basename`) instead of the full path.
- Add CLI regression test: `test_run_command_nested_output_path` in `test_cli.py`.