### PR TITLE
refactor: simplify build() endpoint by removing Windows/Docker duplication (fixes #363)

### DIFF
--- a/fri/server/main.py
+++ b/fri/server/main.py
@@ -190,76 +190,32 @@ def build(dir):
                         
 
     if not os.path.exists(dir_path):
-        if(platform.uname()[0]=='Windows'):
-            if(out_dir == None or out_dir == ""):
-                if(docker == 'true'):
-                    try:
-                        output_bytes = subprocess.check_output(["makedocker", makestudy_dir], cwd=concore_path, shell=True)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Docker study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
-                else:
-                    try:
-                        output_bytes = subprocess.check_output(["makestudy", makestudy_dir], cwd=concore_path, shell=True)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
-            else:
-                if(docker == 'true'):
-                    try:
-                        output_bytes = subprocess.check_output(["makedocker", makestudy_dir, out_dir], cwd=concore_path, shell=True)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Docker study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
-                else:
-                    try:
-                        output_bytes = subprocess.check_output(["makestudy", makestudy_dir, out_dir], cwd=concore_path, shell=True)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
+        # Determine command name and error label based on docker flag
+        if docker == 'true':
+            cmd_name = "makedocker"
+            error_label = "Docker study"
         else:
-            if(out_dir == None or out_dir == ""):
-                if(docker == 'true'):
-                    try:
-                        output_bytes = subprocess.check_output([r"./makedocker", makestudy_dir], cwd=concore_path)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Docker study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
-                else:
-                    try:
-                        output_bytes = subprocess.check_output([r"./makestudy", makestudy_dir], cwd=concore_path)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
-            else:
-                if(docker == 'true'):
-                    try:
-                        output_bytes = subprocess.check_output([r"./makedocker", makestudy_dir, out_dir], cwd=concore_path)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Docker study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
-                else:
-                    try:
-                        output_bytes = subprocess.check_output([r"./makestudy", makestudy_dir, out_dir], cwd=concore_path)
-                        output_str = output_bytes.decode("utf-8")
-                        proc = 0
-                    except subprocess.CalledProcessError as e:
-                        output_str = f"Study creation failed with return code {e.returncode} (check duplicate directory)"
-                        proc = 1
+            cmd_name = "makestudy"
+            error_label = "Study"
+
+        # Build command list
+        cmd = [cmd_name, makestudy_dir]
+        if out_dir != None and out_dir != "":
+            cmd.append(out_dir)
+
+        # OS-specific adjustments
+        is_windows = platform.uname()[0] == 'Windows'
+        if not is_windows:
+            cmd[0] = f"./{cmd[0]}"
+
+        try:
+            output_bytes = subprocess.check_output(cmd, cwd=concore_path, shell=is_windows)
+            output_str = output_bytes.decode("utf-8")
+            proc = 0
+        except subprocess.CalledProcessError as e:
+            output_str = f"{error_label} creation failed with return code {e.returncode} (check duplicate directory)"
+            proc = 1
+
         if(proc == 0):
             resp = jsonify({'message': 'Directory successfully created'})
             resp.status_code = 201


### PR DESCRIPTION
Hello pradeeban Sir,

Fixes #363.

This PR simplifies the `build()` endpoint in `fri/server/main.py`.

Earlier the code had many repeated `try/except` blocks for different cases such as:
- Windows vs POSIX
- Docker vs normal study creation
- With or without `out_dir`

Since the logic was almost the same in each case, the code was hard to read and maintain.

In this PR:
- The command (`makedocker` or `makestudy`) is selected dynamically based on the `docker` flag
- The argument list is built once and `out_dir` is added only if it is provided
- Windows still uses `shell=True` and POSIX still uses the `./` prefix
- The repeated blocks are replaced with a single `try/except`

This removes duplicated code and makes the function easier to maintain.

Changes:
- 69 lines removed
- 25 lines added

No behavior changes:
- Docker builds still use `makedocker`
- Study builds still use `makestudy`
- Response codes and JSON output remain the same

Scope:
- Only `fri/server/main.py` modified
- No changes to `concore-lite`
- No changes to Verilog files

Testing:
- All existing tests pass (77/77)
- Syntax checked with `py_compile`