### PR TITLE
refactor: simplify parameter handling in pidsig.py using concore.tryparam() (fixes #365)

### DIFF
--- a/tools/pidsig.py
+++ b/tools/pidsig.py
@@ -7,34 +7,13 @@ global Prev_Error, I, freq
 Prev_Error = 0
 I = 0
 
-try:
-    sp = concore.params['sp']
-except:
-    sp = 67.5
-try:
-    Kp = concore.params['Kp']
-except:
-    Kp = 0.1
-try:
-    Ki = concore.params['Ki']
-except:
-    Ki = 0.01
-try:
-    Kd = concore.params['Kd']
-except:
-    Kd = 0.03
-try:
-    freq = concore.params['freq']
-except:
-    freq = 30
-try:
-    sigout = concore.params['sigout']
-except:
-    sigout = True 
-try:
-    cin = concore.params['cin']
-except:
-    cin = 'hr' 
+sp = concore.tryparam('sp', 67.5)
+Kp = concore.tryparam('Kp', 0.1)
+Ki = concore.tryparam('Ki', 0.01)
+Kd = concore.tryparam('Kd', 0.03)
+freq = concore.tryparam('freq', 30)
+sigout = concore.tryparam('sigout', True)
+cin = concore.tryparam('cin', 'hr')
 
 def  pid_controller(ym):
     global Prev_Error, I, freq


### PR DESCRIPTION
hello pradeeban Sir
This PR refactors `pidsig.py` to replace 7 repetitive `try/except` blocks used for reading parameters from `concore.params` with clean `concore.tryparam()` calls.

Previously, the file contained blocks like:

    try:
        sp = concore.params['sp']
    except:
        sp = 67.5

This was verbose and used bare `except:`, which silently masks unexpected errors (TypeError, AttributeError, etc.).

 Changes Made

- Replaced all 7 try/except blocks with `concore.tryparam()` one-liners
- Preserved all existing default values exactly:
  - `sp = 67.5`, `Kp = 0.1`, `Ki = 0.01`, `Kd = 0.03`, `freq = 30`, `sigout = True`, `cin = 'hr'`
- Removed all bare `except:` statements
- Reduced ~28 lines to 7 clean one-liners

 Benefits

- Improved readability and maintainability
- Eliminated code duplication
- Removed broad exception handling (`bare except`)
- Consistent with existing code style (as seen in `pidmayuresh.py`)

Scope

- Single file modification: `tools/pidsig.py`
- No behavior changes
- No concore-lite changes
- No Verilog file changes

Testing

- Verified syntax validity (`ast.parse`)
- Verified `tryparam()` returns default when param is missing
- Verified `tryparam()` returns stored value when param exists
- Confirmed no functional differences from original code

Fixes #365