### PR TITLE
fix: use computed PID frequency in pid2.py instead of hardcoded value (fixes #366)

### DIFF
--- a/tools/pid2.py
+++ b/tools/pid2.py
@@ -44,7 +44,7 @@ def  pid_controller(ym):
     if freq<10:
        freq = 10
     Prev_ErrorF = ErrorF      
-    ustar = np.array([amp,30])    
+    ustar = np.array([amp,freq])    
     return ustar
 
 


### PR DESCRIPTION

This PR resolves Issue #366 in `pid2.py`.

The controller correctly computed and clamped a PID-based `freq` value:

    freq = KpF*PF + KiF*IF + KdF*DF
    if freq > 30: freq = 30
    if freq < 10: freq = 10

However, the computed frequency was ignored and replaced with a hardcoded value:

    ustar = np.array([amp, 30])

This effectively disabled dynamic PID frequency control.

Changes Made

- Replaced hardcoded `30` with computed and clamped `freq`
- Preserved all PID gain logic
- Preserved clamping behavior (10–30)

 Impact

- Restores correct PID frequency behavior
- Enables dynamic frequency adjustment based on error feedback
- Fixes functional bug without altering control structure

 Scope

- Single file modification (`tools/pid2.py`)
- Single line changed (1 insertion, 1 deletion)
- No concore-lite changes
- No Verilog changes

Testing

- Verified syntax with `py_compile`
- Simulated PID controller over 50 timesteps: confirmed `freq` varies dynamically (11 unique values observed)
- Verified clamping holds within [10, 30]
- Confirmed output array now reflects computed PID frequency

This restores intended controller functionality.