### PR TITLE
fix: path slash and retry loop in concoredocker.hpp)

### DIFF
--- a/concoredocker.hpp
+++ b/concoredocker.hpp
@@ -81,7 +81,7 @@ public:
 
     std::vector<std::string> read(int port, const std::string& name, const std::string& initstr) {
         std::this_thread::sleep_for(std::chrono::seconds(delay));
-        std::string file_path = inpath + std::to_string(port) + "/" + name;
+        std::string file_path = inpath + "/" + std::to_string(port) + "/" + name;
         std::ifstream infile(file_path);
         std::string ins;
 
@@ -94,6 +94,7 @@ public:
         int attempts = 0, max_retries = 5;
         while (ins.empty() && attempts < max_retries) {
             std::this_thread::sleep_for(std::chrono::seconds(delay));
+            infile.close();
             infile.open(file_path);
             if (infile) std::getline(infile, ins);
             attempts++;
@@ -110,7 +111,7 @@ public:
     }
 
     void write(int port, const std::string& name, const std::vector<std::string>& val, int delta = 0) {
-        std::string file_path = outpath + std::to_string(port) + "/" + name;
+        std::string file_path = outpath + "/" + std::to_string(port) + "/" + name;
         std::ofstream outfile(file_path);
         if (!outfile) {
             std::cerr << "Error writing to " << file_path << "\n";


### PR DESCRIPTION
Fixes #349

Path construction was doing [inpath + std::to_string(port)](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which gives /in1/data instead of /in/1/data, so C++ nodes were reading/writing to a completely different directory than Python nodes. Also, the retry loop was calling [infile.open()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on an already-open stream ,,once failbit is set, open() is a no-op, so it just spins 5 times reading nothing. Added [infile.close()](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) before the reopen.

Two lines changed in read(), one in write().