### PR TITLE
fix: correct Flask-CORS package name in requirements.txt (fixes #368)

### DIFF
--- a/fri/requirements.txt
+++ b/fri/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 gunicorn==20.1.0
-FLASK_CORS
+flask-cors
+# Optional dependency for /openJupyter endpoint
 jupyterlab
 PyGithub


### PR DESCRIPTION
Hello Pradeeban Sir 
This PR resolves Issue #368 by correcting the PyPI package name for Flask-CORS in `fri/requirements.txt`.

Previously:

    FLASK_CORS

While pip may install this due to case-insensitive matching, the official PyPI package name is:

    flask-cors

Using the correct name improves compatibility with:
- dependency lock tools (pip-compile, pip-tools)
- strict package managers (poetry, pdm)
- reproducible builds and Docker images

Changes Made
- Replaced `FLASK_CORS` with `flask-cors` in `fri/requirements.txt`
- Added clarification comment for the optional `jupyterlab` dependency

Verified Locally
- `pip install --dry-run flask-cors` resolves correctly (v6.0.2)
- `pip install --dry-run -r fri/requirements.txt` parses all entries without errors

Scope
- Single file modification (`fri/requirements.txt`)
- No functional changes
- No concore-lite changes
- No Verilog changes

Fixes #368