### PR TITLE
Fix: Replace quit() with sys.exit(1) across scripts (#375)

### DIFF
--- a/0mq/funbody.py
+++ b/0mq/funbody.py
@@ -1,5 +1,6 @@
 import concore
 import time
+import sys
 from osparc_control import CommandManifest
 from osparc_control import CommandParameter
 from osparc_control import CommandType
@@ -58,7 +59,7 @@ while(concore.simtime<concore.maxtime):
            request_id=command.request_id, payload=ym)
     else:
         print("undefined action"+str(command.action)) 
-        quit()
+        sys.exit(1)
     #concore.write(concore.oport['Y1'],"ym",ym)
     print("funbody u="+str(u)+" ym="+str(ym)+" time="+str(concore.simtime))
 paired_transmitter.stop_background_sync()

--- a/demo/cwrap.py
+++ b/demo/cwrap.py
@@ -4,6 +4,7 @@ import requests
 import time
 from ast import literal_eval
 import os
+import sys
 
 #time.sleep(7)
 timeout_max = 20
@@ -86,7 +87,7 @@ while(concore.simtime<concore.maxtime):
     r = requests.post('http://www.controlcore.org/pm/'+yuyu+apikey+'&fetch='+name2, files=f,timeout=timeout_max)
     if r.status_code!=200:
         print("bad POST request "+str(r.status_code))
-        quit()
+        sys.exit(1)
     if len(r.text)!=0:
         try:
             t=literal_eval(r.text)[0]
@@ -107,7 +108,7 @@ while(concore.simtime<concore.maxtime):
         timeout_count += 1
         if r.status_code!=200 or time.perf_counter()-t1 > 1.1*timeout_max: #timeout_count>100:
             print("timeout or bad POST request "+str(r.status_code))
-            quit()
+            sys.exit(1)
         if len(r.text)!=0:
             try:
                 t=literal_eval(r.text)[0]

--- a/demo/pwrap.py
+++ b/demo/pwrap.py
@@ -4,6 +4,7 @@ import requests
 import time
 from ast import literal_eval
 import os
+import sys
 
 #time.sleep(7)
 timeout_max=20
@@ -93,7 +94,7 @@ while(concore.simtime<concore.maxtime):
     r = requests.post('http://www.controlcore.org/ctl/'+yuyu+apikey+'&fetch='+name1, files=f,timeout=timeout_max)
     if r.status_code!=200:
         print("bad POST request "+str(r.status_code))
-        quit()
+        sys.exit(1)
     if len(r.text)!=0:
         try:
             t=literal_eval(r.text)[0]
@@ -114,7 +115,7 @@ while(concore.simtime<concore.maxtime):
         timeout_count += 1
         if r.status_code!=200 or time.perf_counter()-t1 > 1.1*timeout_max: #timeout_count>200:
             print("timeout or bad POST request "+str(r.status_code))
-            quit()
+            sys.exit(1)
         if len(r.text)!=0:
             try:
                 t=literal_eval(r.text)[0]

--- a/tools/pidmayuresh1.py
+++ b/tools/pidmayuresh1.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
 import concore
+import sys
 dT = 0.1
 global Prev_Error, I, freq
 Prev_Error = 0
@@ -22,7 +23,7 @@ def  pid_controller(ym):
         Error = sp - ym[0]
     else:
         print('invalid control input '+cin)
-        quit()
+        sys.exit(1)
     P = Error
     I = I + Error*dT 
     D = (Error - Prev_Error )/dT	

--- a/tools/pidmayuresh3.py
+++ b/tools/pidmayuresh3.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
 import concore
+import sys
 dT = 0.1
 
 sp = concore.tryparam('sp', 67.5)
@@ -20,7 +21,7 @@ def  pid_controller(state, ym, sp, Kp, Ki, Kd, sigout, cin, low, up):
         Error = sp - ym[0]
     else:
         print('invalid control input '+cin)
-        quit()
+        sys.exit(1)
     P = Error
     I = I + Error*dT 
     D = (Error - Prev_Error )/dT	

--- a/tools/pidsig.py
+++ b/tools/pidsig.py
@@ -2,6 +2,7 @@ import numpy as np
 import math
 import concore
 import logging
+import sys
 dT = 0.1
 global Prev_Error, I, freq
 Prev_Error = 0
@@ -23,7 +24,7 @@ def  pid_controller(ym):
         Error = sp - ym[0]
     else:
         logging.error(f'invalid control input {cin}')
-        quit()
+        sys.exit(1)
     P = Error
     I = I + Error*dT 
     D = (Error - Prev_Error )/dT	


### PR DESCRIPTION
Replaced interactive-only `quit()` calls with `sys.exit(1)` to ensure reliable process termination in scripts, Docker containers, and production environments where `site.py` may not be loaded.

**Changes**
- Added `import sys` where missing
- Replaced all `quit()` calls with `sys.exit(1)` in the following files:
  - `demo/cwrap.py` (2 occurrences)
  - `demo/pwrap.py` (2 occurrences)
  - `tools/pidsig.py` (1 occurrence)
  - `tools/pidmayuresh1.py` (1 occurrence)
  - `tools/pidmayuresh3.py` (1 occurrence)
  - `0mq/funbody.py` (1 occurrence)

**Reason**
`quit()` is defined by `site.py` and intended only for the interactive Python interpreter. It is not guaranteed to be available in all runtime environments (e.g., scripts run as services, inside Docker containers, or with `python -S`). `sys.exit()` is the standard, reliable way to terminate a Python process.

**Validation**
- All 6 modified files pass `python -m py_compile` with no syntax errors
- No functional behavior changes only the termination mechanism is updated
- Minimal diff: 6 files changed, 14 insertions, 8 deletions

Fixes #375