### PR TITLE
fix: remove mixed tabs/spaces indentation in bangbang.py (#376)

### DIFF
--- a/humanc/bangbang.py
+++ b/humanc/bangbang.py
@@ -8,9 +8,8 @@ def bangbang_controller(ym):
         amp = 3
     elif ym[1]<65:
         amp = 1
-	    
-     
-    ustar = np.array([amp,30])    
+
+    ustar = np.array([amp,30])
     return ustar
 
 

--- a/tools/bangbang.py
+++ b/tools/bangbang.py
@@ -9,9 +9,8 @@ def bangbang_controller(ym):
         amp = 3
     elif ym[1]<65:
         amp = 1
-	    
-     
-    ustar = np.array([amp,30])    
+
+    ustar = np.array([amp,30])
     return ustar
 
 


### PR DESCRIPTION
hey Pradeeban Sir
Fixes #376 Remove mixed tabs and spaces indentation in `bangbang.py`.

**Problem**
Both `tools/bangbang.py` (line 12) and `humanc/bangbang.py` (line 11) contained
blank lines with mixed tab and space characters (`\t    \r\n`). This violates
PEP 8 indentation rules and can cause `TabError` in Python 3 when tabs and
spaces are mixed in the same block.

**Fix**
Replaced the mixed-indentation blank lines with clean empty lines in both files.
No logic changes purely whitespace cleanup.

**Files Changed**
- `tools/bangbang.py` removed tab+spaces on blank line 12
- `humanc/bangbang.py`  removed tab+spaces on blank line 11

 **Verification**
 Confirm no tabs remain
```
python -c "
for path in ['tools/bangbang.py', 'humanc/bangbang.py']:
    with open(path, 'rb') as f:
        assert b'\t' not in f.read(), f'Tabs in {path}'
    print(f'PASS: {path}')
"
```
**Confirm both files compile**
python -m py_compile tools/bangbang.py
python -m py_compile humanc/bangbang.py