### PR TITLE
 fix: use concore.maxtime in C++ test loops

### DIFF
--- a/testsou/cpymat.cpp
+++ b/testsou/cpymat.cpp
@@ -21,7 +21,7 @@ int main()
   auto wallclock1 = chrono::high_resolution_clock::now();
 
   vector<double> ym;
-  while(concore.simtime<Nsim){
+  while(concore.simtime<concore.maxtime){
     while (concore.unchanged()){
       ym = concore.read(1,"ym",init_simtime_ym);
     }

--- a/testsou/pmpymat.cpp
+++ b/testsou/pmpymat.cpp
@@ -10,13 +10,12 @@ int main()
 {
   Concore concore;
   concore.delay = 0.01;
-  int Nsim = 100;
   string init_simtime_u = "[0.0,0.0,0.0]";
   string init_simtime_ym = "[0.0,0.0,0.0]";
 
   vector<double> ym = concore.initval(init_simtime_ym);
   vector<double> u;
-  while(concore.simtime<Nsim){
+  while(concore.simtime<concore.maxtime){
     while (concore.unchanged()){
       u = concore.read(1,"u",init_simtime_u);
     }

--- a/testsou/powermeter.cpp
+++ b/testsou/powermeter.cpp
@@ -12,14 +12,13 @@ int main(){
     Concore concore2;
     concore.delay = 0.07;
     concore2.delay = 0.07;
-    int Nsim = 100;
     string init_simtime_u = "[0.0,0.0,0.0]";
     string init_simtime_ym = "[0.0,0.0,0.0]";
     int energy = 0;
 
     vector<double> ym = concore.initval(init_simtime_ym);
     vector<double> u;
-    while(concore.simtime<Nsim){
+    while(concore.simtime<concore.maxtime){
         while (concore.unchanged()){
             u = concore.read(concore.iport["VC"],"u",init_simtime_u);
         }


### PR DESCRIPTION
Follow-up to #422 (after #438): changed the C++ test loops to use [concore.maxtime](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of hardcoded [Nsim](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (left [Nsim](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [cpymat.cpp](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) only for avg output)
This keeps C++ runtime termination in line with the other bindings and with configured [maxtime](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html),
