### PR TITLE
fix: dedupe concore/concoredocker shared logic and fix docker path/cleanup behavior

### DIFF
--- a/concore.py
+++ b/concore.py
@@ -9,6 +9,8 @@ import zmq
 import numpy as np
 import signal
 
+import concore_base
+
 logger = logging.getLogger('concore')
 logger.addHandler(logging.NullHandler())
 
@@ -27,117 +29,53 @@ if hasattr(sys, 'getwindowsversion'):
     with open("concorekill.bat","w") as fpid:
         fpid.write("taskkill /F /PID "+str(os.getpid())+"\n")
 
-# ===================================================================
-# ZeroMQ Communication Wrapper
-# ===================================================================
-class ZeroMQPort:
-    def __init__(self, port_type, address, zmq_socket_type):
-        """
-        port_type: "bind" or "connect"
-        address: ZeroMQ address (e.g., "tcp://*:5555")
-        zmq_socket_type: zmq.REQ, zmq.REP, zmq.PUB, zmq.SUB etc.
-        """
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq_socket_type)
-        self.port_type = port_type  # "bind" or "connect"
-        self.address = address
+ZeroMQPort = concore_base.ZeroMQPort
+convert_numpy_to_python = concore_base.convert_numpy_to_python
+safe_literal_eval = concore_base.safe_literal_eval
+parse_params = concore_base.parse_params
 
-        # Configure timeouts & immediate close on failure
-        self.socket.setsockopt(zmq.RCVTIMEO, 2000)   # 2 sec receive timeout
-        self.socket.setsockopt(zmq.SNDTIMEO, 2000)   # 2 sec send timeout
-        self.socket.setsockopt(zmq.LINGER, 0)        # Drop pending messages on close
-
-        # Bind or connect
-        if self.port_type == "bind":
-            self.socket.bind(address)
-            logger.info(f"ZMQ Port bound to {address}")
-        else:
-            self.socket.connect(address)
-            logger.info(f"ZMQ Port connected to {address}")
-            
-    def send_json_with_retry(self, message):
-        """Send JSON message with retries if timeout occurs."""
-        for attempt in range(5):
-            try:
-                self.socket.send_json(message)
-                return
-            except zmq.Again:
-                logger.warning(f"Send timeout (attempt {attempt + 1}/5)")
-                time.sleep(0.5)
-        logger.error("Failed to send after retries.")
-        return
-
-    def recv_json_with_retry(self):
-        """Receive JSON message with retries if timeout occurs."""
-        for attempt in range(5):
-            try:
-                return self.socket.recv_json()
-            except zmq.Again:
-                logger.warning(f"Receive timeout (attempt {attempt + 1}/5)")
-                time.sleep(0.5)
-        logger.error("Failed to receive after retries.")
-        return None
-
-# Global ZeroMQ ports registry
+# Global variables
 zmq_ports = {}
 _cleanup_in_progress = False
 
+s = ''
+olds = ''
+delay = 1
+retrycount = 0
+inpath = "./in" #must be rel path for local
+outpath = "./out"
+simtime = 0
+
+def _port_path(base, port_num):
+    return base + str(port_num)
+
+concore_params_file = os.path.join(_port_path(inpath, 1), "concore.params")
+concore_maxtime_file = os.path.join(_port_path(inpath, 1), "concore.maxtime")
+
+# Load input/output ports if present
+iport = safe_literal_eval("concore.iport", {})
+oport = safe_literal_eval("concore.oport", {})
+
+_mod = sys.modules[__name__]
+
+# ===================================================================
+# ZeroMQ Communication Wrapper
+# ===================================================================
 def init_zmq_port(port_name, port_type, address, socket_type_str):
-    """
-    Initializes and registers a ZeroMQ port.
-    port_name (str): A unique name for this ZMQ port.
-    port_type (str): "bind" or "connect".
-    address (str): The ZMQ address (e.g., "tcp://*:5555", "tcp://localhost:5555").
-    socket_type_str (str): String representation of ZMQ socket type (e.g., "REQ", "REP", "PUB", "SUB").
-    """
-    if port_name in zmq_ports:
-        logger.info(f"ZMQ Port {port_name} already initialized.")
-        return # Avoid reinitialization
-    
-    try:
-        # Map socket type string to actual ZMQ constant (e.g., zmq.REQ, zmq.REP)
-        zmq_socket_type = getattr(zmq, socket_type_str.upper())
-        zmq_ports[port_name] = ZeroMQPort(port_type, address, zmq_socket_type)
-        logger.info(f"Initialized ZMQ port: {port_name} ({socket_type_str}) on {address}")
-    except AttributeError:
-        logger.error(f"Error: Invalid ZMQ socket type string '{socket_type_str}'.")
-    except zmq.error.ZMQError as e:
-        logger.error(f"Error initializing ZMQ port {port_name} on {address}: {e}")
-    except Exception as e:
-        logger.error(f"An unexpected error occurred during ZMQ port initialization for {port_name}: {e}")
+    concore_base.init_zmq_port(_mod, port_name, port_type, address, socket_type_str)
 
 def terminate_zmq():
     """Clean up all ZMQ sockets and contexts before exit."""
-    global _cleanup_in_progress
-    
-    if _cleanup_in_progress:
-        return  # Already cleaning up, prevent reentrant calls
-    
-    if not zmq_ports:
-        return  # No ports to clean up
-    
-    _cleanup_in_progress = True
-    print("\nCleaning up ZMQ resources...")
-    for port_name, port in zmq_ports.items():
-        try:
-            port.socket.close()
-            port.context.term()
-            print(f"Closed ZMQ port: {port_name}")
-        except Exception as e:
-            logger.error(f"Error while terminating ZMQ port {port.address}: {e}")
-    zmq_ports.clear()
-    _cleanup_in_progress = False
+    concore_base.terminate_zmq(_mod)
 
 def signal_handler(sig, frame):
     """Handle interrupt signals gracefully."""
     print(f"\nReceived signal {sig}, shutting down gracefully...")
-    # Prevent terminate_zmq from being called twice: once here and once via atexit
     try:
         atexit.unregister(terminate_zmq)
     except Exception:
-        # If unregister fails for any reason, proceed with explicit cleanup anyway
         pass
-    terminate_zmq()
+    concore_base.terminate_zmq(_mod)
     sys.exit(0)
 
 # Register cleanup handlers
@@ -146,115 +84,12 @@ signal.signal(signal.SIGINT, signal_handler)   # Handle Ctrl+C
 if not hasattr(sys, 'getwindowsversion'):
     signal.signal(signal.SIGTERM, signal_handler)  # Handle termination (Unix only)
 
-# --- ZeroMQ Integration End ---
-
-
-# NumPy Type Conversion Helper
-def convert_numpy_to_python(obj):
-    #Recursively convert numpy types to native Python types.
-    #This is necessary because literal_eval cannot parse numpy representations
-    #like np.float64(1.0), but can parse native Python types like 1.0.
-    if isinstance(obj, np.generic):
-        # Convert numpy scalar types to Python native types
-        return obj.item()
-    elif isinstance(obj, list):
-        return [convert_numpy_to_python(item) for item in obj]
-    elif isinstance(obj, tuple):
-        return tuple(convert_numpy_to_python(item) for item in obj)
-    elif isinstance(obj, dict):
-        return {key: convert_numpy_to_python(value) for key, value in obj.items()}
-    else:
-        return obj
-
-# ===================================================================
-# File & Parameter Handling
-# ===================================================================
-def safe_literal_eval(filename, defaultValue):
-    try:
-        with open(filename, "r") as file:
-            return literal_eval(file.read())
-    except (FileNotFoundError, SyntaxError, ValueError, Exception) as e:
-        # Keep print for debugging, but can be made quieter
-        # print(f"Info: Error reading {filename} or file not found, using default: {e}")
-        return defaultValue
-
-
-# Load input/output ports if present
-iport = safe_literal_eval("concore.iport", {})
-oport = safe_literal_eval("concore.oport", {})
-
-# Global variables
-s = ''
-olds = ''
-delay = 1
-retrycount = 0
-inpath = "./in" #must be rel path for local
-outpath = "./out"
-simtime = 0
-concore_params_file = os.path.join(inpath + "1", "concore.params")
-concore_maxtime_file = os.path.join(inpath + "1", "concore.maxtime")
-
-#9/21/22
-# ===================================================================
-# Parameter Parsing
-# ===================================================================
-def parse_params(sparams: str) -> dict:
-    params = {}
-    if not sparams:
-        return params
-
-    s = sparams.strip()
-
-    #full dict literal
-    if s.startswith("{") and s.endswith("}"):
-        try:
-            val = literal_eval(s)
-            if isinstance(val, dict):
-                return val
-        except (ValueError, SyntaxError):
-            pass
-
-    for item in s.split(";"):
-        if "=" in item:
-            key, value = item.split("=", 1)  # split only once
-            key=key.strip()
-            value=value.strip()
-            #try to convert to python type (int, float, list, etc.)
-            # Use literal_eval to preserve backward compatibility (integers/lists)
-            # Fallback to string for unquoted values (paths, URLs)
-            try:
-                params[key] = literal_eval(value)
-            except (ValueError, SyntaxError):
-                params[key] = value
-    return params
-
-try:
-    sparams_path = concore_params_file
-    if os.path.exists(sparams_path):
-        with open(sparams_path, "r") as f:
-            sparams = f.read().strip()
-        if sparams: # Ensure sparams is not empty
-            # Windows sometimes keeps quotes
-            if sparams[0] == '"' and sparams[-1] == '"':  #windows keeps "" need to remove
-                sparams = sparams[1:-1]
-
-            # Parse params using clean function instead of regex
-            logger.debug("parsing sparams: "+sparams)
-            params = parse_params(sparams)
-            logger.debug("parsed params: " + str(params))
-        else:
-            params = dict()
-    else:
-        params = dict()
-except Exception as e:
-    # print(f"Info: concore.params not found or error reading, using empty dict: {e}")
-    params = dict()
+params = concore_base.load_params(concore_params_file)
 
 #9/30/22
 def tryparam(n, i):
     """Return parameter `n` from params dict, else default `i`."""
     return params.get(n, i)
-
 
 #9/12/21
 # ===================================================================
@@ -269,178 +104,17 @@ default_maxtime(100)
 
 def unchanged():
     """Check if global string `s` is unchanged since last call."""
-    global olds, s
-    if olds == s:
-        s = ''
-        return True
-    olds = s
-    return False
+    return concore_base.unchanged(_mod)
 
 # ===================================================================
 # I/O Handling (File + ZMQ)
 # ===================================================================
 def read(port_identifier, name, initstr_val):
-    global s, simtime, retrycount
-    
-    # Default return
-    default_return_val = initstr_val
-    if isinstance(initstr_val, str):
-        try:
-            default_return_val = literal_eval(initstr_val)
-        except (SyntaxError, ValueError):
-            pass
-    
-    # Case 1: ZMQ port
-    if isinstance(port_identifier, str) and port_identifier in zmq_ports:
-        zmq_p = zmq_ports[port_identifier]
-        try:
-            message = zmq_p.recv_json_with_retry()
-            # Strip simtime prefix if present (mirroring file-based read behavior)
-            if isinstance(message, list) and len(message) > 0:
-                first_element = message[0]
-                if isinstance(first_element, (int, float)):
-                    simtime = max(simtime, first_element)
-                    return message[1:]
-            return message
-        except zmq.error.ZMQError as e:
-            logger.error(f"ZMQ read error on port {port_identifier} (name: {name}): {e}. Returning default.")
-            return default_return_val
-        except Exception as e:
-            logger.error(f"Unexpected error during ZMQ read on port {port_identifier} (name: {name}): {e}. Returning default.")
-            return default_return_val
-
-    # Case 2: File-based port
-    try:
-        file_port_num = int(port_identifier)
-    except ValueError:
-        logger.error(f"Error: Invalid port identifier '{port_identifier}' for file operation. Must be integer or ZMQ name.")
-        return default_return_val
-
-    time.sleep(delay) 
-    file_path = os.path.join(inpath + str(file_port_num), name)
-    ins = ""
-
-    try:
-        with open(file_path, "r") as infile:
-            ins = infile.read()
-    except FileNotFoundError:
-        ins = str(initstr_val) 
-        s += ins  # Update s to break unchanged() loop
-    except Exception as e:
-        logger.error(f"Error reading {file_path}: {e}. Using default value.")
-        return default_return_val 
-
-    # Retry logic if file is empty
-    attempts = 0
-    max_retries = 5 
-    while len(ins) == 0 and attempts < max_retries:
-        time.sleep(delay)
-        try:
-            with open(file_path, "r") as infile:
-                ins = infile.read()
-        except Exception as e:
-            logger.warning(f"Retry {attempts + 1}: Error reading {file_path} - {e}")
-        attempts += 1
-        retrycount += 1
-
-    if len(ins) == 0:
-        logger.error(f"Max retries reached for {file_path}, using default value.")
-        return default_return_val
-
-    s += ins 
-
-    # Try parsing
-    try:
-        inval = literal_eval(ins)
-        if isinstance(inval, list) and len(inval) > 0: 
-            current_simtime_from_file = inval[0]
-            if isinstance(current_simtime_from_file, (int, float)):
-                 simtime = max(simtime, current_simtime_from_file)
-            return inval[1:] 
-        else: 
-            logger.warning(f"Warning: Unexpected data format in {file_path}: {ins}. Returning raw content or default.")
-            return inval 
-    except Exception as e:
-        logger.error(f"Error parsing content from {file_path} ('{ins}'): {e}. Returning default.")
-        return default_return_val
+    return concore_base.read(_mod, port_identifier, name, initstr_val)
 
 
 def write(port_identifier, name, val, delta=0):
-    """
-    Write data either to ZMQ port or file.
-    `val` is the data payload (list or string); write() prepends [simtime + delta] internally.
-    """
-    global simtime
-
-    # Case 1: ZMQ port
-    if isinstance(port_identifier, str) and port_identifier in zmq_ports:
-        zmq_p = zmq_ports[port_identifier]
-        try:
-            # Keep ZMQ payloads JSON-serializable by normalizing numpy types.
-            zmq_val = convert_numpy_to_python(val)
-            if isinstance(zmq_val, list):
-                # Prepend simtime to match file-based write behavior
-                payload = [simtime + delta] + zmq_val
-                zmq_p.send_json_with_retry(payload)
-                # simtime must not be mutated here.
-                # Mutation breaks cross-language determinism (see issue #385).
-            else:
-                zmq_p.send_json_with_retry(zmq_val)
-        except zmq.error.ZMQError as e:
-            logger.error(f"ZMQ write error on port {port_identifier} (name: {name}): {e}")
-        except Exception as e:
-            logger.error(f"Unexpected error during ZMQ write on port {port_identifier} (name: {name}): {e}")
-        return
-    
-    # Case 2: File-based port
-    try:
-        file_port_num = int(port_identifier)
-        file_path = os.path.join(outpath + str(file_port_num), name) 
-    except ValueError:
-        logger.error(f"Error: Invalid port identifier '{port_identifier}' for file operation. Must be integer or ZMQ name.")
-        return
-
-    # File writing rules
-    if isinstance(val, str):
-        time.sleep(2 * delay) # string writes wait longer
-    elif not isinstance(val, list):
-        logger.error(f"File write to {file_path} must have list or str value, got {type(val)}")
-        return
-
-    try:
-        with open(file_path, "w") as outfile:
-            if isinstance(val, list):
-                # Convert numpy types to native Python types
-                val_converted = convert_numpy_to_python(val)
-                data_to_write = [simtime + delta] + val_converted
-                outfile.write(str(data_to_write))
-                # simtime must not be mutated here.
-                # Mutation breaks cross-language determinism (see issue #385).
-            else: 
-                outfile.write(val)
-    except Exception as e:
-        logger.error(f"Error writing to {file_path}: {e}")
+    concore_base.write(_mod, port_identifier, name, val, delta)
 
 def initval(simtime_val_str): 
-    """
-    Initialize simtime from string containing a list.
-    Example: "[10, 'foo', 'bar']" → simtime=10, returns ['foo','bar']
-    """
-    global simtime
-    try:
-        val = literal_eval(simtime_val_str)
-        if isinstance(val, list) and len(val) > 0:
-            first_element = val[0]
-            if isinstance(first_element, (int, float)):
-                simtime = first_element
-                return val[1:] 
-            else:
-                logger.error(f"Error: First element in initval string '{simtime_val_str}' is not a number. Using data part as is or empty.")
-                return val[1:] if len(val) > 1 else [] 
-        else: 
-            logger.error(f"Error: initval string '{simtime_val_str}' is not a list or is empty. Returning empty list.")
-            return []
-
-    except Exception as e:
-        logger.error(f"Error parsing simtime_val_str '{simtime_val_str}': {e}. Returning empty list.")
-        return []
+    return concore_base.initval(_mod, simtime_val_str)

--- a/concore_base.py
+++ b/concore_base.py
@@ -1,0 +1,364 @@
+import time
+import logging
+import os
+from ast import literal_eval
+import zmq
+import numpy as np
+
+logger = logging.getLogger('concore')
+logger.addHandler(logging.NullHandler())
+
+# ===================================================================
+# ZeroMQ Communication Wrapper
+# ===================================================================
+class ZeroMQPort:
+    def __init__(self, port_type, address, zmq_socket_type):
+        """
+        port_type: "bind" or "connect"
+        address: ZeroMQ address (e.g., "tcp://*:5555")
+        zmq_socket_type: zmq.REQ, zmq.REP, zmq.PUB, zmq.SUB etc.
+        """
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq_socket_type)
+        self.port_type = port_type  # "bind" or "connect"
+        self.address = address
+
+        # Configure timeouts & immediate close on failure
+        self.socket.setsockopt(zmq.RCVTIMEO, 2000)   # 2 sec receive timeout
+        self.socket.setsockopt(zmq.SNDTIMEO, 2000)   # 2 sec send timeout
+        self.socket.setsockopt(zmq.LINGER, 0)        # Drop pending messages on close
+
+        # Bind or connect
+        if self.port_type == "bind":
+            self.socket.bind(address)
+            logger.info(f"ZMQ Port bound to {address}")
+        else:
+            self.socket.connect(address)
+            logger.info(f"ZMQ Port connected to {address}")
+            
+    def send_json_with_retry(self, message):
+        """Send JSON message with retries if timeout occurs."""
+        for attempt in range(5):
+            try:
+                self.socket.send_json(message)
+                return
+            except zmq.Again:
+                logger.warning(f"Send timeout (attempt {attempt + 1}/5)")
+                time.sleep(0.5)
+        logger.error("Failed to send after retries.")
+        return
+
+    def recv_json_with_retry(self):
+        """Receive JSON message with retries if timeout occurs."""
+        for attempt in range(5):
+            try:
+                return self.socket.recv_json()
+            except zmq.Again:
+                logger.warning(f"Receive timeout (attempt {attempt + 1}/5)")
+                time.sleep(0.5)
+        logger.error("Failed to receive after retries.")
+        return None
+
+
+def init_zmq_port(mod, port_name, port_type, address, socket_type_str):
+    """
+    Initializes and registers a ZeroMQ port.
+    mod: calling module (has zmq_ports dict)
+    port_name (str): A unique name for this ZMQ port.
+    port_type (str): "bind" or "connect".
+    address (str): The ZMQ address (e.g., "tcp://*:5555", "tcp://localhost:5555").
+    socket_type_str (str): String representation of ZMQ socket type (e.g., "REQ", "REP", "PUB", "SUB").
+    """
+    if port_name in mod.zmq_ports:
+        logger.info(f"ZMQ Port {port_name} already initialized.")
+        return # Avoid reinitialization
+    
+    try:
+        # Map socket type string to actual ZMQ constant (e.g., zmq.REQ, zmq.REP)
+        zmq_socket_type = getattr(zmq, socket_type_str.upper())
+        mod.zmq_ports[port_name] = ZeroMQPort(port_type, address, zmq_socket_type)
+        logger.info(f"Initialized ZMQ port: {port_name} ({socket_type_str}) on {address}")
+    except AttributeError:
+        logger.error(f"Error: Invalid ZMQ socket type string '{socket_type_str}'.")
+    except zmq.error.ZMQError as e:
+        logger.error(f"Error initializing ZMQ port {port_name} on {address}: {e}")
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during ZMQ port initialization for {port_name}: {e}")
+
+def terminate_zmq(mod):
+    """Clean up all ZMQ sockets and contexts before exit."""
+    if mod._cleanup_in_progress:
+        return  # Already cleaning up, prevent reentrant calls
+    
+    if not mod.zmq_ports:
+        return  # No ports to clean up
+    
+    mod._cleanup_in_progress = True
+    print("\nCleaning up ZMQ resources...")
+    for port_name, port in mod.zmq_ports.items():
+        try:
+            port.socket.close()
+            port.context.term()
+            print(f"Closed ZMQ port: {port_name}")
+        except Exception as e:
+            logger.error(f"Error while terminating ZMQ port {port.address}: {e}")
+    mod.zmq_ports.clear()
+    mod._cleanup_in_progress = False
+
+# --- ZeroMQ Integration End ---
+
+
+# NumPy Type Conversion Helper
+def convert_numpy_to_python(obj):
+    #Recursively convert numpy types to native Python types.
+    #This is necessary because literal_eval cannot parse numpy representations
+    #like np.float64(1.0), but can parse native Python types like 1.0.
+    if isinstance(obj, np.generic):
+        # Convert numpy scalar types to Python native types
+        return obj.item()
+    elif isinstance(obj, list):
+        return [convert_numpy_to_python(item) for item in obj]
+    elif isinstance(obj, tuple):
+        return tuple(convert_numpy_to_python(item) for item in obj)
+    elif isinstance(obj, dict):
+        return {key: convert_numpy_to_python(value) for key, value in obj.items()}
+    else:
+        return obj
+
+# ===================================================================
+# File & Parameter Handling
+# ===================================================================
+def safe_literal_eval(filename, defaultValue):
+    try:
+        with open(filename, "r") as file:
+            return literal_eval(file.read())
+    except (FileNotFoundError, SyntaxError, ValueError, Exception) as e:
+        # print(f"Info: Error reading {filename} or file not found, using default: {e}")
+        return defaultValue
+
+#9/21/22
+# ===================================================================
+# Parameter Parsing
+# ===================================================================
+def parse_params(sparams):
+    params = {}
+    if not sparams:
+        return params
+
+    s = sparams.strip()
+
+    #full dict literal
+    if s.startswith("{") and s.endswith("}"):
+        try:
+            val = literal_eval(s)
+            if isinstance(val, dict):
+                return val
+        except (ValueError, SyntaxError):
+            pass
+
+    for item in s.split(";"):
+        if "=" in item:
+            key, value = item.split("=", 1)  # split only once
+            key=key.strip()
+            value=value.strip()
+            #try to convert to python type (int, float, list, etc.)
+            # Use literal_eval to preserve backward compatibility (integers/lists)
+            # Fallback to string for unquoted values (paths, URLs)
+            try:
+                params[key] = literal_eval(value)
+            except (ValueError, SyntaxError):
+                params[key] = value
+    return params
+
+def load_params(params_file):
+    try:
+        if os.path.exists(params_file):
+            with open(params_file, "r") as f:
+                sparams = f.read().strip()
+            if sparams:
+                # Windows sometimes keeps quotes
+                if sparams[0] == '"' and sparams[-1] == '"':  #windows keeps "" need to remove
+                    sparams = sparams[1:-1]
+                logger.debug("parsing sparams: "+sparams)
+                p = parse_params(sparams)
+                logger.debug("parsed params: " + str(p))
+                return p
+        return dict()
+    except Exception:
+        return dict()
+
+# ===================================================================
+# I/O Handling (File + ZMQ)
+# ===================================================================
+
+def unchanged(mod):
+    """Check if global string `s` is unchanged since last call."""
+    if mod.olds == mod.s:
+        mod.s = ''
+        return True
+    mod.olds = mod.s
+    return False
+
+
+def read(mod, port_identifier, name, initstr_val):
+    # Default return
+    default_return_val = initstr_val
+    if isinstance(initstr_val, str):
+        try:
+            default_return_val = literal_eval(initstr_val)
+        except (SyntaxError, ValueError):
+            pass
+    
+    # Case 1: ZMQ port
+    if isinstance(port_identifier, str) and port_identifier in mod.zmq_ports:
+        zmq_p = mod.zmq_ports[port_identifier]
+        try:
+            message = zmq_p.recv_json_with_retry()
+            # Strip simtime prefix if present (mirroring file-based read behavior)
+            if isinstance(message, list) and len(message) > 0:
+                first_element = message[0]
+                if isinstance(first_element, (int, float)):
+                    mod.simtime = max(mod.simtime, first_element)
+                    return message[1:]
+            return message
+        except zmq.error.ZMQError as e:
+            logger.error(f"ZMQ read error on port {port_identifier} (name: {name}): {e}. Returning default.")
+            return default_return_val
+        except Exception as e:
+            logger.error(f"Unexpected error during ZMQ read on port {port_identifier} (name: {name}): {e}. Returning default.")
+            return default_return_val
+
+    # Case 2: File-based port
+    try:
+        file_port_num = int(port_identifier)
+    except ValueError:
+        logger.error(f"Error: Invalid port identifier '{port_identifier}' for file operation. Must be integer or ZMQ name.")
+        return default_return_val
+
+    time.sleep(mod.delay) 
+    port_dir = mod._port_path(mod.inpath, file_port_num)
+    file_path = os.path.join(port_dir, name)
+    ins = ""
+
+    try:
+        with open(file_path, "r") as infile:
+            ins = infile.read()
+    except FileNotFoundError:
+        ins = str(initstr_val) 
+        mod.s += ins  # Update s to break unchanged() loop
+    except Exception as e:
+        logger.error(f"Error reading {file_path}: {e}. Using default value.")
+        return default_return_val 
+
+    # Retry logic if file is empty
+    attempts = 0
+    max_retries = 5 
+    while len(ins) == 0 and attempts < max_retries:
+        time.sleep(mod.delay)
+        try:
+            with open(file_path, "r") as infile:
+                ins = infile.read()
+        except Exception as e:
+            logger.warning(f"Retry {attempts + 1}: Error reading {file_path} - {e}")
+        attempts += 1
+        mod.retrycount += 1
+
+    if len(ins) == 0:
+        logger.error(f"Max retries reached for {file_path}, using default value.")
+        return default_return_val
+
+    mod.s += ins 
+
+    # Try parsing
+    try:
+        inval = literal_eval(ins)
+        if isinstance(inval, list) and len(inval) > 0: 
+            current_simtime_from_file = inval[0]
+            if isinstance(current_simtime_from_file, (int, float)):
+                 mod.simtime = max(mod.simtime, current_simtime_from_file)
+            return inval[1:] 
+        else: 
+            logger.warning(f"Warning: Unexpected data format in {file_path}: {ins}. Returning raw content or default.")
+            return inval 
+    except Exception as e:
+        logger.error(f"Error parsing content from {file_path} ('{ins}'): {e}. Returning default.")
+        return default_return_val
+
+
+def write(mod, port_identifier, name, val, delta=0):
+    """
+    Write data either to ZMQ port or file.
+    `val` is the data payload (list or string); write() prepends [simtime + delta] internally.
+    """
+    # Case 1: ZMQ port
+    if isinstance(port_identifier, str) and port_identifier in mod.zmq_ports:
+        zmq_p = mod.zmq_ports[port_identifier]
+        try:
+            # Keep ZMQ payloads JSON-serializable by normalizing numpy types.
+            zmq_val = convert_numpy_to_python(val)
+            if isinstance(zmq_val, list):
+                # Prepend simtime to match file-based write behavior
+                payload = [mod.simtime + delta] + zmq_val
+                zmq_p.send_json_with_retry(payload)
+                # simtime must not be mutated here.
+                # Mutation breaks cross-language determinism (see issue #385).
+            else:
+                zmq_p.send_json_with_retry(zmq_val)
+        except zmq.error.ZMQError as e:
+            logger.error(f"ZMQ write error on port {port_identifier} (name: {name}): {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error during ZMQ write on port {port_identifier} (name: {name}): {e}")
+        return
+    
+    # Case 2: File-based port
+    try:
+        file_port_num = int(port_identifier)
+        port_dir = mod._port_path(mod.outpath, file_port_num)
+        file_path = os.path.join(port_dir, name) 
+    except ValueError:
+        logger.error(f"Error: Invalid port identifier '{port_identifier}' for file operation. Must be integer or ZMQ name.")
+        return
+
+    # File writing rules
+    if isinstance(val, str):
+        time.sleep(2 * mod.delay) # string writes wait longer
+    elif not isinstance(val, list):
+        logger.error(f"File write to {file_path} must have list or str value, got {type(val)}")
+        return
+
+    try:
+        with open(file_path, "w") as outfile:
+            if isinstance(val, list):
+                # Convert numpy types to native Python types
+                val_converted = convert_numpy_to_python(val)
+                data_to_write = [mod.simtime + delta] + val_converted
+                outfile.write(str(data_to_write))
+                # simtime must not be mutated here.
+                # Mutation breaks cross-language determinism (see issue #385).
+            else: 
+                outfile.write(val)
+    except Exception as e:
+        logger.error(f"Error writing to {file_path}: {e}")
+
+def initval(mod, simtime_val_str): 
+    """
+    Initialize simtime from string containing a list.
+    Example: "[10, 'foo', 'bar']" -> simtime=10, returns ['foo','bar']
+    """
+    try:
+        val = literal_eval(simtime_val_str)
+        if isinstance(val, list) and len(val) > 0:
+            first_element = val[0]
+            if isinstance(first_element, (int, float)):
+                mod.simtime = first_element
+                return val[1:] 
+            else:
+                logger.error(f"Error: First element in initval string '{simtime_val_str}' is not a number. Using data part as is or empty.")
+                return val[1:] if len(val) > 1 else [] 
+        else: 
+            logger.error(f"Error: initval string '{simtime_val_str}' is not a list or is empty. Returning empty list.")
+            return []
+
+    except Exception as e:
+        logger.error(f"Error parsing simtime_val_str '{simtime_val_str}': {e}. Returning empty list.")
+        return []

--- a/concoredocker.py
+++ b/concoredocker.py
@@ -3,115 +3,27 @@ from ast import literal_eval
 import re
 import os
 import logging
+import atexit
+import sys
 import zmq
 import numpy as np
+import signal
+
+import concore_base
 
 logging.basicConfig(
     level=logging.INFO,
     format='%(levelname)s - %(message)s'
 )
 
-class ZeroMQPort:
-    def __init__(self, port_type, address, zmq_socket_type):
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq_socket_type)
-        self.port_type = port_type
-        self.address = address
+ZeroMQPort = concore_base.ZeroMQPort
+convert_numpy_to_python = concore_base.convert_numpy_to_python
+safe_literal_eval = concore_base.safe_literal_eval
+parse_params = concore_base.parse_params
 
-        # Configure timeouts & immediate close on failure
-        self.socket.setsockopt(zmq.RCVTIMEO, 2000)   # 2 sec receive timeout
-        self.socket.setsockopt(zmq.SNDTIMEO, 2000)   # 2 sec send timeout
-        self.socket.setsockopt(zmq.LINGER, 0)        # Drop pending messages on close
-
-        # Bind or connect
-        if self.port_type == "bind":
-            self.socket.bind(address)
-            logging.info(f"ZMQ Port bound to {address}")
-        else:
-            self.socket.connect(address)
-            logging.info(f"ZMQ Port connected to {address}")
-            
-    def send_json_with_retry(self, message):
-        """Send JSON message with retries if timeout occurs."""
-        for attempt in range(5):
-            try:
-                self.socket.send_json(message)
-                return
-            except zmq.Again:
-                logging.warning(f"Send timeout (attempt {attempt + 1}/5)")
-                time.sleep(0.5)
-        logging.error("Failed to send after retries.")
-        return
-
-    def recv_json_with_retry(self):
-        """Receive JSON message with retries if timeout occurs."""
-        for attempt in range(5):
-            try:
-                return self.socket.recv_json()
-            except zmq.Again:
-                logging.warning(f"Receive timeout (attempt {attempt + 1}/5)")
-                time.sleep(0.5)
-        logging.error("Failed to receive after retries.")
-        return None
-
-# Global ZeroMQ ports registry
+# Global variables
 zmq_ports = {}
-
-def init_zmq_port(port_name, port_type, address, socket_type_str):
-    """
-    Initializes and registers a ZeroMQ port.
-    port_name (str): A unique name for this ZMQ port.
-    port_type (str): "bind" or "connect".
-    address (str): The ZMQ address (e.g., "tcp://*:5555", "tcp://localhost:5555").
-    socket_type_str (str): String representation of ZMQ socket type (e.g., "REQ", "REP", "PUB", "SUB").
-    """
-    if port_name in zmq_ports:
-        logging.info(f"ZMQ Port {port_name} already initialized.")
-        return#avoid reinstallation
-    try:
-        # Map socket type string to actual ZMQ constant (e.g., zmq.REQ, zmq.REP)
-        zmq_socket_type = getattr(zmq, socket_type_str.upper())
-        zmq_ports[port_name] = ZeroMQPort(port_type, address, zmq_socket_type)
-        logging.info(f"Initialized ZMQ port: {port_name} ({socket_type_str}) on {address}")
-    except AttributeError:
-        logging.error(f"Error: Invalid ZMQ socket type string '{socket_type_str}'.")
-    except zmq.error.ZMQError as e:
-        logging.error(f"Error initializing ZMQ port {port_name} on {address}: {e}")
-    except Exception as e:
-        logging.error(f"An unexpected error occurred during ZMQ port initialization for {port_name}: {e}")
-
-def terminate_zmq():
-    for port in zmq_ports.values():
-        try:
-            port.socket.close()
-            port.context.term()
-        except Exception as e:
-            logging.error(f"Error while terminating ZMQ port {port.address}: {e}")
-# --- ZeroMQ Integration End ---
-
-# NumPy Type Conversion Helper
-def convert_numpy_to_python(obj):
-    if isinstance(obj, np.generic):
-        return obj.item()
-    elif isinstance(obj, list):
-        return [convert_numpy_to_python(item) for item in obj]
-    elif isinstance(obj, tuple):
-        return tuple(convert_numpy_to_python(item) for item in obj)
-    elif isinstance(obj, dict):
-        return {key: convert_numpy_to_python(value) for key, value in obj.items()}
-    else:
-        return obj
-
-def safe_literal_eval(filename, defaultValue):
-    try:
-        with open(filename, "r") as file:
-            return literal_eval(file.read())
-    except (FileNotFoundError, SyntaxError, ValueError, Exception) as e:
-        logging.info(f"Error reading {filename}: {e}")
-        return defaultValue
-    
-iport = safe_literal_eval("concore.iport", {})
-oport = safe_literal_eval("concore.oport", {})
+_cleanup_in_progress = False
 
 s = ''
 olds = ''
@@ -120,59 +32,45 @@ retrycount = 0
 inpath = os.path.abspath("/in")
 outpath = os.path.abspath("/out")
 simtime = 0
-concore_params_file = os.path.join(inpath + "1", "concore.params")
-concore_maxtime_file = os.path.join(inpath + "1", "concore.maxtime")
 
-#9/21/22
-def parse_params(sparams):
-    params = {}
-    if not sparams:
-        return params
+def _port_path(base, port_num):
+    return os.path.join(base, str(port_num))
 
-    s = sparams.strip()
+concore_params_file = os.path.join(_port_path(inpath, 1), "concore.params")
+concore_maxtime_file = os.path.join(_port_path(inpath, 1), "concore.maxtime")
 
-    # full dict literal
-    if s.startswith("{") and s.endswith("}"):
-        try:
-            val = literal_eval(s)
-            if isinstance(val, dict):
-                return val
-        except (ValueError, SyntaxError):
-            pass
+# Load input/output ports if present
+iport = safe_literal_eval("concore.iport", {})
+oport = safe_literal_eval("concore.oport", {})
 
-    # Potentially breaking backward compatibility: moving away from the comma-separated params
-    for item in s.split(";"):
-        if "=" in item:
-            key, value = item.split("=", 1)
-            key = key.strip()
-            value = value.strip()
-            #try to convert to python type (int, float, list, etc.)
-            # Use literal_eval to preserve backward compatibility (integers/lists)
-            # Fallback to string for unquoted values (paths, URLs)
-            try:
-                params[key] = literal_eval(value)
-            except (ValueError, SyntaxError):
-                params[key] = value
-    return params
+_mod = sys.modules[__name__]
 
-try:
-    with open(concore_params_file, "r") as f:
-        sparams = f.read().strip()
+# ===================================================================
+# ZeroMQ Communication Wrapper
+# ===================================================================
+def init_zmq_port(port_name, port_type, address, socket_type_str):
+    concore_base.init_zmq_port(_mod, port_name, port_type, address, socket_type_str)
 
-    if sparams and sparams[0] == '"':  # windows keeps quotes
-        sparams = sparams[1:]
-        if '"' in sparams:
-            sparams = sparams[:sparams.find('"')]
+def terminate_zmq():
+    """Clean up all ZMQ sockets and contexts before exit."""
+    concore_base.terminate_zmq(_mod)
 
-    if sparams:
-        logging.debug("parsing sparams: "+sparams)
-        params = parse_params(sparams)
-        logging.debug("parsed params: " + str(params))
-    else:
-        params = dict()
-except Exception as e:
-    logging.error(f"Error reading concore.params: {e}")
-    params = dict()
+def signal_handler(sig, frame):
+    """Handle interrupt signals gracefully."""
+    print(f"\nReceived signal {sig}, shutting down gracefully...")
+    try:
+        atexit.unregister(terminate_zmq)
+    except Exception:
+        pass
+    concore_base.terminate_zmq(_mod)
+    sys.exit(0)
+
+# Register cleanup handlers (docker containers receive SIGTERM from docker stop)
+atexit.register(terminate_zmq)
+signal.signal(signal.SIGINT, signal_handler)
+signal.signal(signal.SIGTERM, signal_handler)
+
+params = concore_base.load_params(concore_params_file)
 
 #9/30/22
 def tryparam(n, i):
@@ -186,156 +84,16 @@ def default_maxtime(default):
 default_maxtime(100)
 
 def unchanged():
-    global olds, s
-    if olds == s:
-        s = ''
-        return True
-    olds = s
-    return False
+    return concore_base.unchanged(_mod)
 
+# ===================================================================
+# I/O Handling (File + ZMQ)
+# ===================================================================
 def read(port_identifier, name, initstr_val):
-    global s, simtime, retrycount
-    
-    default_return_val = initstr_val
-    if isinstance(initstr_val, str):
-        try:
-            default_return_val = literal_eval(initstr_val)
-        except (SyntaxError, ValueError):
-            # Failed to parse initstr_val; fall back to the original string value.
-            logging.debug(
-                "Could not parse initstr_val %r with literal_eval; using raw string as default.",
-                initstr_val
-            )
-    
-    if isinstance(port_identifier, str) and port_identifier in zmq_ports:
-        zmq_p = zmq_ports[port_identifier]
-        try:
-            message = zmq_p.recv_json_with_retry()
-            if isinstance(message, list) and len(message) > 0:
-                first_element = message[0]
-                if isinstance(first_element, (int, float)):
-                    simtime = max(simtime, first_element)
-                    return message[1:]
-            return message
-        except zmq.error.ZMQError as e:
-            logging.error(f"ZMQ read error on port {port_identifier} (name: {name}): {e}. Returning default.")
-            return default_return_val
-        except Exception as e:
-            logging.error(f"Unexpected error during ZMQ read on port {port_identifier} (name: {name}): {e}. Returning default.")
-            return default_return_val
-
-    try:
-        file_port_num = int(port_identifier)
-    except ValueError:
-        logging.error(f"Error: Invalid port identifier '{port_identifier}' for file operation. Must be integer or ZMQ name.")
-        return default_return_val
-
-    time.sleep(delay)
-    # Construct file path consistent with other components (e.g., /in1/<name>)
-    file_path = os.path.join(inpath, str(file_port_num), name)
-
-    try:
-        with open(file_path, "r") as infile:
-            ins = infile.read()
-    except FileNotFoundError:
-        ins = str(initstr_val)
-        s += ins
-    except Exception as e:
-        logging.error(f"Error reading {file_path}: {e}. Using default value.")
-        return default_return_val
-
-    attempts = 0
-    max_retries = 5
-    while len(ins) == 0 and attempts < max_retries:
-        time.sleep(delay)
-        try:
-            with open(file_path, "r") as infile:
-                ins = infile.read()
-        except Exception as e:
-            logging.warning(f"Retry {attempts + 1}: Error reading {file_path} - {e}")
-        attempts += 1
-        retrycount += 1
-
-    if len(ins) == 0:
-        logging.error(f"Max retries reached for {file_path}, using default value.")
-        return default_return_val
-
-    s += ins
-    try:
-        inval = literal_eval(ins)
-        if isinstance(inval, list) and len(inval) > 0:
-            current_simtime_from_file = inval[0]
-            if isinstance(current_simtime_from_file, (int, float)):
-                simtime = max(simtime, current_simtime_from_file)
-            return inval[1:]
-        else:
-            logging.warning(f"Warning: Unexpected data format in {file_path}: {ins}. Returning raw content or default.")
-            return inval
-    except Exception as e:
-        logging.error(f"Error parsing content from {file_path} ('{ins}'): {e}. Returning default.")
-        return default_return_val
+    return concore_base.read(_mod, port_identifier, name, initstr_val)
 
 def write(port_identifier, name, val, delta=0):
-    global simtime
-    
-    if isinstance(port_identifier, str) and port_identifier in zmq_ports:
-        zmq_p = zmq_ports[port_identifier]
-        try:
-            zmq_val = convert_numpy_to_python(val)
-            if isinstance(zmq_val, list):
-                # Prepend simtime to match file-based write behavior
-                payload = [simtime + delta] + zmq_val
-                zmq_p.send_json_with_retry(payload)
-                simtime += delta
-            else:
-                zmq_p.send_json_with_retry(zmq_val)
-        except zmq.error.ZMQError as e:
-            logging.error(f"ZMQ write error on port {port_identifier} (name: {name}): {e}")
-        except Exception as e:
-            logging.error(f"Unexpected error during ZMQ write on port {port_identifier} (name: {name}): {e}")
-        return
-
-    try:
-        file_port_num = int(port_identifier)
-        file_path = os.path.join(outpath, str(file_port_num), name)
-    except ValueError:
-        logging.error(f"Error: Invalid port identifier '{port_identifier}' for file operation. Must be integer or ZMQ name.")
-        return
-
-    if isinstance(val, str):
-        time.sleep(2 * delay)
-    elif not isinstance(val, list):
-        logging.error(f"File write to {file_path} must have list or str value, got {type(val)}")
-        return
-
-    try:
-        with open(file_path, "w") as outfile:
-            if isinstance(val, list):
-                val_converted = convert_numpy_to_python(val)
-                data_to_write = [simtime + delta] + val_converted
-                outfile.write(str(data_to_write))
-                simtime += delta
-            else:
-                outfile.write(val)
-    except Exception as e:
-        logging.error(f"Error writing to {file_path}: {e}")
+    concore_base.write(_mod, port_identifier, name, val, delta)
 
 def initval(simtime_val):
-    global simtime
-    try:
-        val = literal_eval(simtime_val)
-        if isinstance(val, list) and len(val) > 0:
-            first_element = val[0]
-            if isinstance(first_element, (int, float)):
-                simtime = first_element
-                return val[1:]
-            else:
-                logging.error(f"Error: First element in initval string '{simtime_val}' is not a number. Using data part as is or empty.")
-                return val[1:] if len(val) > 1 else []
-        else:
-            logging.error(f"Error: initval string '{simtime_val}' is not a list or is empty. Returning empty list.")
-            return []
-    except Exception as e:
-        logging.error(f"Error parsing simtime_val_str '{simtime_val}': {e}. Returning empty list.")
-        return []
-
+    return concore_base.initval(_mod, simtime_val)

--- a/mkconcore.py
+++ b/mkconcore.py
@@ -574,6 +574,13 @@ if 'py' in required_langs:
     with open(outdir+"/src/concore.py","w") as fcopy:
         fcopy.write(fsource.read())
     fsource.close()
+    try:
+        with open(CONCOREPATH+"/concore_base.py") as fbase:
+            with open(outdir+"/src/concore_base.py","w") as fcopy:
+                fcopy.write(fbase.read())
+    except (FileNotFoundError, IOError):
+        print(CONCOREPATH+" is not correct path to concore (missing concore_base.py)")
+        quit()
 
 if 'cpp' in required_langs:
     try:
@@ -767,6 +774,7 @@ if (concoretype=="docker"):
             fbuild.write("cp ../src/"+sourcecode+" .\n")
             if langext == "py": #4/29/21
                 fbuild.write("cp ../src/concore.py .\n")
+                fbuild.write("cp ../src/concore_base.py .\n")
             elif langext == "cpp": #6/22/21
                 fbuild.write("cp ../src/concore.hpp .\n")
             elif langext == "v": #6/25/21
@@ -1005,6 +1013,7 @@ for node in nodes_dict:
             fbuild.write("copy .\\src\\"+sourcecode+" .\\"+containername+"\\"+sourcecode+"\n")
             if langext == "py":
                 fbuild.write("copy .\\src\\concore.py .\\" + containername + "\\concore.py\n")
+                fbuild.write("copy .\\src\\concore_base.py .\\" + containername + "\\concore_base.py\n")
             elif langext == "cpp":
  # 6/22/21
                 fbuild.write("copy .\\src\\concore.hpp .\\" + containername + "\\concore.hpp\n")
@@ -1023,6 +1032,7 @@ for node in nodes_dict:
             fbuild.write("cp ./src/"+sourcecode+" ./"+containername+"/"+sourcecode+"\n")
             if langext == "py":
                 fbuild.write("cp ./src/concore.py ./"+containername+"/concore.py\n")
+                fbuild.write("cp ./src/concore_base.py ./"+containername+"/concore_base.py\n")
             elif langext == "cpp":
                 fbuild.write("cp ./src/concore.hpp ./"+containername+"/concore.hpp\n")
             elif langext == "v":

--- a/tests/test_concoredocker.py
+++ b/tests/test_concoredocker.py
@@ -109,7 +109,8 @@ class TestWrite:
         with open(os.path.join(outdir, "testfile")) as f:
             content = f.read()
         assert content == "[12.0, 3.0]"
-        assert concoredocker.simtime == 12.0
+        # simtime must not be mutated by write()
+        assert concoredocker.simtime == 10.0
         concoredocker.outpath = old_outpath
 
 
@@ -180,7 +181,8 @@ class TestZMQ:
         concoredocker.write("test_zmq", "data", [1.0, 2.0], delta=2)
 
         assert dummy.sent == [5.0, 1.0, 2.0]
-        assert concoredocker.simtime == 5.0
+        # simtime must not be mutated by write()
+        assert concoredocker.simtime == 3.0
 
     def test_read_strips_simtime(self):
         import concoredocker


### PR DESCRIPTION
`concoredocker.py` was a stale copy of `concore.py` with bugs. Moved shared logic into `concore_base.py`, both are now thin wrappers, also fixes docker path, ZMQ cleanup, and write() mutating simtime



<img width="646" height="297" alt="image" src="https://github.com/user-attachments/assets/fc530831-200b-4c34-be60-84b3da386696" />


Closes #436

