### PR TITLE
Realtime simulation plotting

### DIFF
--- a/demo/plotym.py
+++ b/demo/plotym.py
@@ -9,6 +9,15 @@ concore.default_maxtime(150)
 init_simtime_u = "[0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0]"
 ymt = []
+
+plt.ion() # enable interactive mode
+fig, ax = plt.subplots(1, 1)
+
+line, = ax.plot([], [])
+ax.set_ylabel('ym')
+ax.legend(['ym'], loc=0)
+ax.set_xlabel('Cycles')
+
 ym = concore.initval(init_simtime_ym)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
@@ -16,19 +25,22 @@ while(concore.simtime<concore.maxtime):
     concore.write(1,"ym",ym)
     print("ym="+str(ym))
     ymt.append(np.array(ym).T)
+
+    #real-time update
+    Nsim = len(ymt)
+    
+    #update line dynamically
+    line.set_data(range(Nsim), [x[0].item() for x in ymt])
+    ax.relim()
+    ax.autoscale_view()
+    
+    plt.pause(0.001) # Render update
+
 print("retry="+str(concore.retrycount))
 
 #################
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-
-Nsim = len(ym1)
-plt.figure()
-plt.subplot(111)
-plt.plot(range(Nsim), ym1)
-plt.ylabel('ym')
-plt.legend(['ym'], loc=0)
-plt.xlabel('Cycles')
+# Final Save & cleanup
+plt.ioff()
 plt.savefig("ym.pdf")
 plt.show()

--- a/example/plotym.py
+++ b/example/plotym.py
@@ -1,34 +1,55 @@
 import concore
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-print("plotym")
+logging.info("plot ym")
 
-concore.delay = 0.02
+concore.delay = 0.005
 concore.default_maxtime(150)
-init_simtime_u = "[0.0, 0.0]"
-init_simtime_ym = "[0.0, 0.0]"
+init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
+init_simtime_ym = "[0.0, 0.0, 0.0]"
+ut = []
 ymt = []
+plt.ion() # Enable interactive mode
+fig, (ax1, ax2) = plt.subplots(2, 1)
+
+line1, = ax1.plot([], [])
+ax1.set_ylabel('MAP (mmHg)')
+ax1.legend(['MAP'], loc=0)
+
+line2, = ax2.plot([], [])
+ax2.set_xlabel('Cycles '+str(concore.params))
+ax2.set_ylabel('HR (bpm)')
+ax2.legend(['HR'], loc=0)
+
 ym = concore.initval(init_simtime_ym)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         ym = concore.read(1,"ym",init_simtime_ym)
     concore.write(1,"ym",ym)
-    print("ym="+str(ym))
+    logging.debug(f" ym={ym}")
     ymt.append(np.array(ym).T)
-print("retry="+str(concore.retrycount))
+
+    #real-time update
+    Nsim = len(ymt)
+    xdata = range(Nsim)
+    
+    # Extract columns and update lines directly
+    line1.set_data(xdata, [x[0].item() for x in ymt])
+    line2.set_data(xdata, [x[1].item() for x in ymt])
+    
+    for ax in (ax1, ax2):
+        ax.relim()
+        ax.autoscale_view()
+
+    plt.pause(0.001) # Render update
+
+logging.info(f"retry={concore.retrycount}")
 
 #################
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-
-Nsim = len(ym1)
-plt.figure()
-plt.subplot(111)
-plt.plot(range(Nsim), ym1)
-plt.ylabel('ym')
-plt.legend(['ym'], loc=0)
-plt.xlabel('Cycles')
-plt.savefig("ym.pdf")
+# Final Save & cleanup
+plt.ioff()
+plt.savefig("hrmap.pdf")
 plt.show()

--- a/ratc/cvxpymatcore.py
+++ b/ratc/cvxpymatcore.py
@@ -118,6 +118,36 @@ ymt = []
 concore.delay = 0.02
 init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
+
+# --- LIVE PLOT SETUP ---
+if GENERATE_PLOT == 1:
+    plt.ion() # Enable interactive mode
+    
+    # 1. Setup hrmap figure (Outputs & Setpoints)
+    fig_ym, (ax_map, ax_hr) = plt.subplots(2, 1)
+    line_map_m, = ax_map.plot([], [], label='MAPm')
+    line_map_sp, = ax_map.plot([], [], label='MAPsp')
+    ax_map.set_ylabel('MAP (mmHg)')
+    ax_map.legend(loc=0)
+    
+    line_hr_m, = ax_hr.plot([], [], label='HRm')
+    line_hr_sp, = ax_hr.plot([], [], label='HRsp')
+    ax_hr.set_xlabel('Cycles')
+    ax_hr.set_ylabel('HR (bpm)')
+    ax_hr.legend(loc=0)
+
+    # 2. Setup stim figure (Inputs)
+    fig_u, axs_u = plt.subplots(3, 2)
+    lines_u = []
+    labels_u = ['Pw1 (s)', 'Pf1 (Hz)', 'Pw2 (s)', 'Pf2 (Hz)', 'Pw3 (s)', 'Pf3 (Hz)']
+    for i, ax in enumerate(axs_u.flat):
+        line, = ax.plot([], [])
+        ax.set_ylabel(labels_u[i])
+        if i >= 4: ax.set_xlabel('Cycles')
+        lines_u.append((ax, line))
+    fig_u.tight_layout()
+# ------------------------
+
 u = np.array([concore.initval(init_simtime_u)]).T
 wallclock1 = time.perf_counter()
 while(concore.simtime<concore.maxtime):
@@ -129,8 +159,34 @@ while(concore.simtime<concore.maxtime):
     ymt.append(ym)
     u, xc, Pd = MPC(xc, u, ym, Pd, X)
     #################
+    
+    # --- LIVE UPDATE ---
+    if GENERATE_PLOT == 1:
+        Nsim = len(ymt)
+        xdata = range(Nsim)
+        
+        # Update hrmap figure
+        line_map_m.set_data(xdata, [x[0].item() for x in ymt])
+        line_map_sp.set_data(xdata, np.tile(X['ysp'][0], Nsim))
+        line_hr_m.set_data(xdata, [x[1].item() for x in ymt])
+        line_hr_sp.set_data(xdata, np.tile(X['ysp'][1], Nsim))
+        
+        for ax in (ax_map, ax_hr):
+            ax.relim()
+            ax.autoscale_view()
+            
+        # Update stim figure
+        for i, (ax, line) in enumerate(lines_u):
+            line.set_data(xdata, [x[i].item() for x in ut])
+            ax.relim()
+            ax.autoscale_view()
+
+        plt.pause(0.001) # Render updates
+    # -------------------
+
     print("ym="+str(ym)+" u="+str(u));
     concore.write(1,"u",list(u.T[0]));
+    
 wallclock2 = time.perf_counter()
 #concore.write(1,"u",init_simtime_u)
 print("retry="+str(concore.retrycount))
@@ -139,55 +195,8 @@ print("time/iter="+str((wallclock2-wallclock1)/concore.maxtime))
 if GENERATE_PLOT == 0:
     quit()
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-ym2 = [x[1].item() for x in ymt]
-u1 = [x[0].item() for x in ut]
-u2 = [x[1].item() for x in ut]
-u3 = [x[2].item() for x in ut]
-u4 = [x[3].item() for x in ut]
-u5 = [x[4].item() for x in ut]
-u6 = [x[5].item() for x in ut]
-
-Nsim = len(ym1)
-plt.figure()
-plt.subplot(211)
-plt.plot(range(Nsim), ym1)
-plt.plot(range(Nsim), np.tile(X['ysp'][0], Nsim))
-plt.ylabel('MAP (mmHg)')
-plt.legend(['MAPm', 'MAPsp'], loc=0)
-plt.subplot(212)
-plt.plot(range(Nsim), ym2)
-plt.plot(range(Nsim), np.tile(X['ysp'][1], Nsim))
-plt.xlabel('Cycles')
-plt.ylabel('HR (bpm)')
-plt.legend(['HRm', 'HRsp'], loc=0)
-plt.savefig("hrmap.pdf")
-#plt.tight_layout()
-
-plt.figure()
-plt.subplot(321)
-plt.plot(range(Nsim), u1)
-plt.ylabel('Pw1 (s)')
-plt.subplot(322)
-plt.plot(range(Nsim), u2)
-plt.ylabel('Pf1 (Hz)')
-plt.subplot(323)
-plt.plot(range(Nsim), u3)
-plt.xlabel('Cycles')
-plt.ylabel('Pw2 (s)')
-plt.subplot(324)
-plt.plot(range(Nsim), u4)
-plt.ylabel('Pf2 (Hz)')
-plt.subplot(325)
-plt.plot(range(Nsim), u5)
-plt.ylabel('Pw3 (s)')
-plt.subplot(326)
-plt.plot(range(Nsim), u6)
-plt.xlabel('Cycles')
-plt.ylabel('Pf3 (Hz)')
-plt.savefig("stim.pdf")
-plt.tight_layout()
-plt.show()
-
-
+# --- FINAL SAVE & CLEANUP ---
+plt.ioff()
+fig_ym.savefig("hrmap.pdf")
+fig_u.savefig("stim.pdf")
+plt.show() # Keep plots open at the end

--- a/ratc/cvxpysp.py
+++ b/ratc/cvxpysp.py
@@ -116,11 +116,11 @@ print(X['A'])
 u = X['us']                          # initial input
 print("initial input")
 print(X['us'])
-# initialize controller constant and variables
-#Nsim =  150                          # number of simulation cycles
+
 concore.default_maxtime(150)
 xc = np.zeros((X['Nx'], 1))          # initial conditon of state in MPC
 Pd = X['Pd']                         # variance of initial state
+
 # set list to record inputs and outputs
 ut = []
 ymt = []
@@ -129,19 +129,76 @@ ymt = []
 concore.delay = 0.02
 init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
+
+# --- LIVE PLOT SETUP (Moved from bottom) ---
+if GENERATE_PLOT == 1:
+    plt.ion() # Enable interactive mode
+    
+    # 1. Setup hrmap figure (Outputs & Setpoints)
+    fig_ym, (ax_map, ax_hr) = plt.subplots(2, 1)
+    line_map_m, = ax_map.plot([], [], label='MAPm')
+    line_map_sp, = ax_map.plot([], [], label='MAPsp')
+    ax_map.set_ylabel('MAP (mmHg)')
+    ax_map.legend(loc=0)
+    
+    line_hr_m, = ax_hr.plot([], [], label='HRm')
+    line_hr_sp, = ax_hr.plot([], [], label='HRsp')
+    ax_hr.set_xlabel('Cycles')
+    ax_hr.set_ylabel('HR (bpm)')
+    ax_hr.legend(loc=0)
+
+    # 2. Setup stim figure (Inputs)
+    fig_u, axs_u = plt.subplots(3, 2)
+    lines_u = []
+    labels_u = ['Pw1 (s)', 'Pf1 (Hz)', 'Pw2 (s)', 'Pf2 (Hz)', 'Pw3 (s)', 'Pf3 (Hz)']
+    for i, ax in enumerate(axs_u.flat):
+        line, = ax.plot([], [])
+        ax.set_ylabel(labels_u[i])
+        if i >= 4: ax.set_xlabel('Cycles')
+        lines_u.append((ax, line))
+    fig_u.tight_layout()
+# -------------------------------------------
+
 u = np.array([concore.initval(init_simtime_u)]).T
 wallclock1 = time.perf_counter()
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         ym = concore.read(1,"ym",init_simtime_ym)
     ym = np.array([ym]).T
+    
     #################
     ut.append(u)
     ymt.append(ym)
     u, xc, Pd = MPC(xc, u, ym, Pd, X)
     #################
+
+    # --- LIVE UPDATE ---
+    if GENERATE_PLOT == 1:
+        Nsim = len(ymt)
+        xdata = range(Nsim)
+        
+        # Update hrmap figure (Outputs & Setpoints)
+        line_map_m.set_data(xdata, [x[0].item() for x in ymt])
+        line_map_sp.set_data(xdata, np.tile(X['ysp'][0], Nsim))
+        line_hr_m.set_data(xdata, [x[1].item() for x in ymt])
+        line_hr_sp.set_data(xdata, np.tile(X['ysp'][1], Nsim))
+        
+        for ax in (ax_map, ax_hr):
+            ax.relim()
+            ax.autoscale_view()
+            
+        # Update stim figure (Inputs)
+        for i, (ax, line) in enumerate(lines_u):
+            line.set_data(xdata, [x[i].item() for x in ut])
+            ax.relim()
+            ax.autoscale_view()
+
+        plt.pause(0.001) # Render updates
+    # -------------------
+
     print("ym="+str(ym)+" u="+str(u));
     concore.write(1,"u",list(u.T[0]));
+    
 wallclock2 = time.perf_counter()
 #concore.write(1,"u",init_simtime_u)
 print("retry="+str(concore.retrycount))
@@ -150,55 +207,10 @@ print("time/iter="+str((wallclock2-wallclock1)/concore.maxtime))
 if GENERATE_PLOT == 0:
     quit()
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-ym2 = [x[1].item() for x in ymt]
-u1 = [x[0].item() for x in ut]
-u2 = [x[1].item() for x in ut]
-u3 = [x[2].item() for x in ut]
-u4 = [x[3].item() for x in ut]
-u5 = [x[4].item() for x in ut]
-u6 = [x[5].item() for x in ut]
-
-Nsim = len(ym1)
-plt.figure()
-plt.subplot(211)
-plt.plot(range(Nsim), ym1)
-plt.plot(range(Nsim), np.tile(X['ysp'][0], Nsim))
-plt.ylabel('MAP (mmHg)')
-plt.legend(['MAPm', 'MAPsp'], loc=0)
-plt.subplot(212)
-plt.plot(range(Nsim), ym2)
-plt.plot(range(Nsim), np.tile(X['ysp'][1], Nsim))
-plt.xlabel('Cycles')
-plt.ylabel('HR (bpm)')
-plt.legend(['HRm', 'HRsp'], loc=0)
-plt.savefig("hrmap.pdf")
-#plt.tight_layout()
-
-plt.figure()
-plt.subplot(321)
-plt.plot(range(Nsim), u1)
-plt.ylabel('Pw1 (s)')
-plt.subplot(322)
-plt.plot(range(Nsim), u2)
-plt.ylabel('Pf1 (Hz)')
-plt.subplot(323)
-plt.plot(range(Nsim), u3)
-plt.xlabel('Cycles')
-plt.ylabel('Pw2 (s)')
-plt.subplot(324)
-plt.plot(range(Nsim), u4)
-plt.ylabel('Pf2 (Hz)')
-plt.subplot(325)
-plt.plot(range(Nsim), u5)
-plt.ylabel('Pw3 (s)')
-plt.subplot(326)
-plt.plot(range(Nsim), u6)
-plt.xlabel('Cycles')
-plt.ylabel('Pf3 (Hz)')
-plt.savefig("stim.pdf")
-plt.tight_layout()
+# --- FINAL SAVE & CLEANUP ---
+plt.ioff()
+fig_ym.savefig("hrmap.pdf")
+fig_u.savefig("stim.pdf")
 plt.show()
 
 

--- a/ratc/learn.py
+++ b/ratc/learn.py
@@ -13,63 +13,71 @@ ym = concore.initval(init_simtime_ym)
 ut = (concore.maxtime+1)*[np.array(u).T]
 ymt = (concore.maxtime+1)*[np.array(ym).T]
 oldsimtime = concore.simtime
+
+# --- LIVE PLOT SETUP ---
+if GENERATE_PLOT == 1:
+    plt.ion() # Enable interactive mode
+    
+    # Setup stim figure (Inputs)
+    fig_u, axs_u = plt.subplots(3, 2)
+    lines_u = []
+    labels_u = ['Pw1 (s)', 'Pf1 (Hz)', 'Pw2 (s)', 'Pf2 (Hz)', 'Pw3 (s)', 'Pf3 (Hz)']
+    for i, ax in enumerate(axs_u.flat):
+        line, = ax.plot([], [])
+        ax.set_ylabel(labels_u[i])
+        if i >= 4: ax.set_xlabel('Learn Cycles')
+        lines_u.append((ax, line))
+    fig_u.tight_layout()
+
+    # Setup hrmap figure (Outputs)
+    fig_ym, (ax_map, ax_hr) = plt.subplots(2, 1)
+    line_map, = ax_map.plot([], [], label='Learn MAP')
+    ax_map.set_ylabel('MAP (mmHg)')
+    ax_map.legend(loc=0)
+    
+    line_hr, = ax_hr.plot([], [], label='Learn HR')
+    ax_hr.set_xlabel('Cycles')
+    ax_hr.set_ylabel('HR (bpm)')
+    ax_hr.legend(loc=0)
+# ------------------------
+
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         u = concore.read(concore.iport["VCY"],"u",init_simtime_u)
         ym = concore.read(concore.iport["VPY"],"ym",init_simtime_ym)
+    
     if concore.simtime > oldsimtime:
-        ut[int(concore.simtime)] = np.array(u).T
-        ymt[int(concore.simtime)] = np.array(ym).T
+        curr_idx = int(concore.simtime)
+        ut[curr_idx] = np.array(u).T
+        ymt[curr_idx] = np.array(ym).T
+        
+        # --- LIVE UPDATE ---
+        if GENERATE_PLOT == 1:
+            xdata = range(curr_idx + 1)
+            
+            # Update Inputs
+            for i, (ax, line) in enumerate(lines_u):
+                line.set_data(xdata, [x[i].item() for x in ut[:curr_idx + 1]])
+                ax.relim()
+                ax.autoscale_view()
+                
+            # Update Outputs
+            line_map.set_data(xdata, [x[0].item() for x in ymt[:curr_idx + 1]])
+            line_hr.set_data(xdata, [x[1].item() for x in ymt[:curr_idx + 1]])
+            for ax in (ax_map, ax_hr):
+                ax.relim()
+                ax.autoscale_view()
+                
+            plt.pause(0.001) # Render updates
+        # -------------------
+        
     oldsimtime = concore.simtime
 print("retry="+str(concore.retrycount))
 
 #################
-# plot inputs and outputs
-
+# --- FINAL SAVE & CLEANUP ---
 if GENERATE_PLOT == 1:
- u1 = [x[0].item() for x in ut]
- u2 = [x[1].item() for x in ut]
- u3 = [x[2].item() for x in ut]
- u4 = [x[3].item() for x in ut]
- u5 = [x[4].item() for x in ut]
- u6 = [x[5].item() for x in ut]
- Nsim = len(u1)
- plt.figure()
- plt.subplot(321)
- plt.plot(range(Nsim), u1)
- plt.ylabel('Pw1 (s)')
- plt.subplot(322)
- plt.plot(range(Nsim), u2)
- plt.ylabel('Pf1 (Hz)')
- plt.subplot(323)
- plt.plot(range(Nsim), u3)
- plt.xlabel('Learn Cycles')
- plt.ylabel('Pw2 (s)')
- plt.subplot(324)
- plt.plot(range(Nsim), u4)
- plt.ylabel('Pf2 (Hz)')
- plt.subplot(325)
- plt.plot(range(Nsim), u5)
- plt.ylabel('Pw3 (s)')
- plt.subplot(326)
- plt.plot(range(Nsim), u6)
- plt.xlabel('Learn Cycles')
- plt.ylabel('Pf3 (Hz)')
- plt.savefig("stim.pdf")
- plt.tight_layout()
-
- ym1 = [x[0].item() for x in ymt]
- ym2 = [x[1].item() for x in ymt]
- Nsim = len(ym1)
- plt.figure()
- plt.subplot(211)
- plt.plot(range(Nsim), ym1)
- plt.ylabel('MAP (mmHg)')
- plt.legend(['Learn MAP'], loc=0)
- plt.subplot(212)
- plt.plot(range(Nsim), ym2)
- plt.xlabel('Cycles')
- plt.ylabel('HR (bpm)')
- plt.legend(['Learn HR'], loc=0)
- plt.savefig("hrmap.pdf")
- plt.show()
+    plt.ioff()
+    fig_u.savefig("stim.pdf")
+    fig_ym.savefig("hrmap.pdf")
+    plt.show() # Keep plot open at the end

--- a/ratc/learn2.py
+++ b/ratc/learn2.py
@@ -2,7 +2,8 @@ import concore
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-GENERATE_PLOT = 0
+
+GENERATE_PLOT = 1 # Set to 1 to enable the live plot
 fout=open(concore.outpath+'1/history.txt','w')
 fout2=open('historyfull.txt','a+')
 concore.delay = 0.002
@@ -14,16 +15,68 @@ ym = concore.initval(init_simtime_ym)
 ut = (concore.maxtime+1)*[np.array(u).T]
 ymt = (concore.maxtime+1)*[np.array(ym).T]
 oldsimtime = concore.simtime
+
+# --- LIVE PLOT SETUP ---
+if GENERATE_PLOT == 1:
+    plt.ion() # Enable interactive mode
+    
+    # Setup stim figure (Inputs)
+    fig_u, axs_u = plt.subplots(3, 2)
+    lines_u = []
+    labels_u = ['Pw1 (s)', 'Pf1 (Hz)', 'Pw2 (s)', 'Pf2 (Hz)', 'Pw3 (s)', 'Pf3 (Hz)']
+    for i, ax in enumerate(axs_u.flat):
+        line, = ax.plot([], [])
+        ax.set_ylabel(labels_u[i])
+        if i >= 4: ax.set_xlabel('Learn Cycles')
+        lines_u.append((ax, line))
+    fig_u.tight_layout()
+
+    # Setup hrmap figure (Outputs)
+    fig_ym, (ax_map, ax_hr) = plt.subplots(2, 1)
+    line_map, = ax_map.plot([], [], label='Learn MAP')
+    ax_map.set_ylabel('MAP (mmHg)')
+    ax_map.legend(loc=0)
+    
+    line_hr, = ax_hr.plot([], [], label='Learn HR')
+    ax_hr.set_xlabel('Cycles')
+    ax_hr.set_ylabel('HR (bpm)')
+    ax_hr.legend(loc=0)
+# ------------------------
+
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         u = concore.read(concore.iport["VCY"],"u",init_simtime_u)
         ym = concore.read(concore.iport["VPY"],"ym",init_simtime_ym)
+        
     if concore.simtime > oldsimtime:
-        ut[int(concore.simtime)] = np.array(u).T
-        ymt[int(concore.simtime)] = np.array(ym).T
+        curr_idx = int(concore.simtime)
+        ut[curr_idx] = np.array(u).T
+        ymt[curr_idx] = np.array(ym).T
         #fout.write(str(u)+str(ym)+'\n')
         #fout2.write(str(u)+str(ym)+'\n')
+        
+        # --- LIVE UPDATE ---
+        if GENERATE_PLOT == 1:
+            xdata = range(curr_idx + 1)
+            
+            # Update Inputs
+            for i, (ax, line) in enumerate(lines_u):
+                line.set_data(xdata, [x[i].item() for x in ut[:curr_idx + 1]])
+                ax.relim()
+                ax.autoscale_view()
+                
+            # Update Outputs
+            line_map.set_data(xdata, [x[0].item() for x in ymt[:curr_idx + 1]])
+            line_hr.set_data(xdata, [x[1].item() for x in ymt[:curr_idx + 1]])
+            for ax in (ax_map, ax_hr):
+                ax.relim()
+                ax.autoscale_view()
+                
+            plt.pause(0.001) # Render updates
+        # -------------------
+        
     oldsimtime = concore.simtime
+    
 print("retry="+str(concore.retrycount))
 
 for i in range(2,concore.maxtime):
@@ -33,52 +86,9 @@ fout.close()
 fout2.close()
 
 #################
-# plot inputs and outputs
-
+# --- FINAL SAVE & CLEANUP ---
 if GENERATE_PLOT == 1:
- u1 = [x[0].item() for x in ut]
- u2 = [x[1].item() for x in ut]
- u3 = [x[2].item() for x in ut]
- u4 = [x[3].item() for x in ut]
- u5 = [x[4].item() for x in ut]
- u6 = [x[5].item() for x in ut]
- Nsim = len(u1)
- plt.figure()
- plt.subplot(321)
- plt.plot(range(Nsim), u1)
- plt.ylabel('Pw1 (s)')
- plt.subplot(322)
- plt.plot(range(Nsim), u2)
- plt.ylabel('Pf1 (Hz)')
- plt.subplot(323)
- plt.plot(range(Nsim), u3)
- plt.xlabel('Learn Cycles')
- plt.ylabel('Pw2 (s)')
- plt.subplot(324)
- plt.plot(range(Nsim), u4)
- plt.ylabel('Pf2 (Hz)')
- plt.subplot(325)
- plt.plot(range(Nsim), u5)
- plt.ylabel('Pw3 (s)')
- plt.subplot(326)
- plt.plot(range(Nsim), u6)
- plt.xlabel('Learn Cycles')
- plt.ylabel('Pf3 (Hz)')
- plt.savefig("stim.pdf")
- plt.tight_layout()
-
- ym1 = [x[0].item() for x in ymt]
- ym2 = [x[1].item() for x in ymt]
- Nsim = len(ym1)
- plt.figure()
- plt.subplot(211)
- plt.plot(range(Nsim), ym1)
- plt.ylabel('MAP (mmHg)')
- plt.legend(['Learn MAP'], loc=0)
- plt.subplot(212)
- plt.plot(range(Nsim), ym2)
- plt.xlabel('Cycles')
- plt.ylabel('HR (bpm)')
- plt.legend(['Learn HR'], loc=0)
- plt.savefig("hrmap.pdf")
- plt.show()
+    plt.ioff()
+    fig_u.savefig("stim.pdf")
+    fig_ym.savefig("hrmap.pdf")
+    plt.show() # Keep plot open at the end

--- a/ratc/learn3.py
+++ b/ratc/learn3.py
@@ -2,7 +2,8 @@ import concore
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-GENERATE_PLOT = 0
+
+GENERATE_PLOT = 1
 concore.delay = 0.002
 concore.simtime = 0
 
@@ -15,15 +16,65 @@ u = concore.initval(init_simtime_u)
 ym = concore.initval(init_simtime_ym)
 ut = (concore.maxtime+1)*[np.array(u).T]
 ymt = (concore.maxtime+1)*[np.array(ym).T]
+
+# --- LIVE PLOT SETUP ---
+if GENERATE_PLOT == 1:
+    plt.ion() # Enable interactive mode
+    
+    # 1. Setup stim figure (Inputs)
+    fig_u, axs_u = plt.subplots(3, 2)
+    lines_u = []
+    labels_u = ['Pw1 (s)', 'Pf1 (Hz)', 'Pw2 (s)', 'Pf2 (Hz)', 'Pw3 (s)', 'Pf3 (Hz)']
+    for i, ax in enumerate(axs_u.flat):
+        line, = ax.plot([], [])
+        ax.set_ylabel(labels_u[i])
+        if i >= 4: ax.set_xlabel('Learn Cycles')
+        lines_u.append((ax, line))
+    fig_u.tight_layout()
+
+    # 2. Setup hrmap figure (Outputs)
+    fig_ym, (ax_map, ax_hr) = plt.subplots(2, 1)
+    line_map, = ax_map.plot([], [], label='Learn MAP')
+    ax_map.set_ylabel('MAP (mmHg)')
+    ax_map.legend(loc=0)
+    
+    line_hr, = ax_hr.plot([], [], label='Learn HR')
+    ax_hr.set_xlabel('Cycles')
+    ax_hr.set_ylabel('HR (bpm)')
+    ax_hr.legend(loc=0)
+# ------------------------
+
 while(concore.simtime<concore.maxtime-1):
     while concore.unchanged():
         u = concore.read(concore.iport["VCY"],"u",init_simtime_u)
-    ut[int(concore.simtime)] = np.array(u).T
+    
+    current_idx = int(concore.simtime)
+    ut[current_idx] = np.array(u).T
+    
     while concore.unchanged():
         ym = concore.read(concore.iport["VPY"],"ym",init_simtime_ym)
-    ymt[int(concore.simtime)] = np.array(ym).T
-    #fout.write(str(u)+str(ym)+'\n')
-    #fout2.write(str(u)+str(ym)+'\n')
+    ymt[current_idx] = np.array(ym).T
+    
+    # --- LIVE UPDATE ---
+    if GENERATE_PLOT == 1:
+        xdata = range(current_idx + 1)
+        
+        # Update Inputs (slice up to current_idx)
+        for i, (ax, line) in enumerate(lines_u):
+            line.set_data(xdata, [x[i].item() for x in ut[:current_idx + 1]])
+            ax.relim()
+            ax.autoscale_view()
+            
+        # Update Outputs (slice up to current_idx)
+        line_map.set_data(xdata, [x[0].item() for x in ymt[:current_idx + 1]])
+        line_hr.set_data(xdata, [x[1].item() for x in ymt[:current_idx + 1]])
+        for ax in (ax_map, ax_hr):
+            ax.relim()
+            ax.autoscale_view()
+
+        plt.pause(0.001) # Render updates
+    # -------------------
+
 print("retry="+str(concore.retrycount))
 
 for i in range(2,concore.maxtime):
@@ -32,53 +83,9 @@ for i in range(2,concore.maxtime):
 fout.close()
 fout2.close()
 
-#################
-# plot inputs and outputs
-
+# --- FINAL SAVE & CLEANUP ---
 if GENERATE_PLOT == 1:
- u1 = [x[0].item() for x in ut]
- u2 = [x[1].item() for x in ut]
- u3 = [x[2].item() for x in ut]
- u4 = [x[3].item() for x in ut]
- u5 = [x[4].item() for x in ut]
- u6 = [x[5].item() for x in ut]
- Nsim = len(u1)
- plt.figure()
- plt.subplot(321)
- plt.plot(range(Nsim), u1)
- plt.ylabel('Pw1 (s)')
- plt.subplot(322)
- plt.plot(range(Nsim), u2)
- plt.ylabel('Pf1 (Hz)')
- plt.subplot(323)
- plt.plot(range(Nsim), u3)
- plt.xlabel('Learn Cycles')
- plt.ylabel('Pw2 (s)')
- plt.subplot(324)
- plt.plot(range(Nsim), u4)
- plt.ylabel('Pf2 (Hz)')
- plt.subplot(325)
- plt.plot(range(Nsim), u5)
- plt.ylabel('Pw3 (s)')
- plt.subplot(326)
- plt.plot(range(Nsim), u6)
- plt.xlabel('Learn Cycles')
- plt.ylabel('Pf3 (Hz)')
- plt.savefig("stim.pdf")
- plt.tight_layout()
-
- ym1 = [x[0].item() for x in ymt]
- ym2 = [x[1].item() for x in ymt]
- Nsim = len(ym1)
- plt.figure()
- plt.subplot(211)
- plt.plot(range(Nsim), ym1)
- plt.ylabel('MAP (mmHg)')
- plt.legend(['Learn MAP'], loc=0)
- plt.subplot(212)
- plt.plot(range(Nsim), ym2)
- plt.xlabel('Cycles')
- plt.ylabel('HR (bpm)')
- plt.legend(['Learn HR'], loc=0)
- plt.savefig("hrmap.pdf")
- plt.show()
+    plt.ioff()
+    fig_u.savefig("stim.pdf")
+    fig_ym.savefig("hrmap.pdf")
+    plt.show() # Keep plot open at the end

--- a/ratc/plotu.py
+++ b/ratc/plotu.py
@@ -1,8 +1,9 @@
 import concore
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-print("plot u")
+logging.info("plot u")
 
 concore.delay = 0.005
 concore.default_maxtime(150)
@@ -10,49 +11,59 @@ init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 ut = []
 ymt = []
+
+plt.ion()       #interactive plotting
+plt.figure()    #initialize the figure before the loop
+
 u = concore.initval(init_simtime_u)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         u = concore.read(1,"u",init_simtime_u)
     concore.write(1,"u",u)
-    print("u="+str(u))
+    logging.debug(f"u={u}")
     ut.append(np.array(u).T)
-print("retry="+str(concore.retrycount))
 
-#################
+    #update plot every 5 cycles to prevent drawing lag
+    if len(ut) % 5 == 0: 
+        plt.clf() # clear the figure to draw the fresh frame
 
-# plot inputs and outputs
-u1 = [x[0].item() for x in ut]
-u2 = [x[1].item() for x in ut]
-u3 = [x[2].item() for x in ut]
-u4 = [x[3].item() for x in ut]
-u5 = [x[4].item() for x in ut]
-u6 = [x[5].item() for x in ut]
+        u1 = [x[0].item() for x in ut]
+        u2 = [x[1].item() for x in ut]
+        u3 = [x[2].item() for x in ut]
+        u4 = [x[3].item() for x in ut]
+        u5 = [x[4].item() for x in ut]
+        u6 = [x[5].item() for x in ut]
 
-Nsim = len(u1)
-plt.figure()
-plt.subplot(321)
-plt.plot(range(Nsim), u1)
-plt.ylabel('Pw1 (s)')
-plt.subplot(322)
-plt.plot(range(Nsim), u2)
-plt.ylabel('Pf1 (Hz)')
-plt.subplot(323)
-plt.plot(range(Nsim), u3)
-plt.xlabel('Cycles')
-plt.ylabel('Pw2 (s)')
-plt.subplot(324)
-plt.plot(range(Nsim), u4)
-plt.ylabel('Pf2 (Hz)')
-plt.subplot(325)
-plt.plot(range(Nsim), u5)
-plt.ylabel('Pw3 (s)')
-plt.subplot(326)
-plt.plot(range(Nsim), u6)
-plt.xlabel('Cycles')
-plt.ylabel('Pf3 (Hz)')
+        Nsim = len(u1)
+        plt.subplot(321)
+        plt.plot(range(Nsim), u1)
+        plt.ylabel('Pw1 (s)')
+        plt.subplot(322)
+        plt.plot(range(Nsim), u2)
+        plt.ylabel('Pf1 (Hz)')
+        plt.subplot(323)
+        plt.plot(range(Nsim), u3)
+        plt.xlabel('Cycles')
+        plt.ylabel('Pw2 (s)')
+        plt.subplot(324)
+        plt.plot(range(Nsim), u4)
+        plt.ylabel('Pf2 (Hz)')
+        plt.subplot(325)
+        plt.plot(range(Nsim), u5)
+        plt.ylabel('Pw3 (s)')
+        plt.subplot(326)
+        plt.plot(range(Nsim), u6)
+        plt.xlabel('Cycles')
+        plt.ylabel('Pf3 (Hz)')
+        plt.tight_layout()
+        
+        plt.pause(0.001)
+
+logging.info(f"retry={concore.retrycount}")
+
+#post-simulation cleanup
+plt.ioff()               
 plt.savefig("stim.pdf")
-plt.tight_layout()
 plt.show()
 
 

--- a/ratc/plotym.py
+++ b/ratc/plotym.py
@@ -1,8 +1,9 @@
 import concore
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-print("plot ym")
+logging.info("plot ym")
 
 concore.delay = 0.005
 concore.default_maxtime(150)
@@ -10,31 +11,45 @@ init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 ut = []
 ymt = []
+plt.ion() # Enable interactive mode
+fig, (ax1, ax2) = plt.subplots(2, 1)
+
+line1, = ax1.plot([], [])
+ax1.set_ylabel('MAP (mmHg)')
+ax1.legend(['MAP'], loc=0)
+
+line2, = ax2.plot([], [])
+ax2.set_xlabel('Cycles '+str(concore.params))
+ax2.set_ylabel('HR (bpm)')
+ax2.legend(['HR'], loc=0)
+
 ym = concore.initval(init_simtime_ym)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         ym = concore.read(1,"ym",init_simtime_ym)
     concore.write(1,"ym",ym)
-    print(" ym="+str(ym))
+    logging.debug(f" ym={ym}")
     ymt.append(np.array(ym).T)
-print("retry="+str(concore.retrycount))
+
+    #real-time update
+    Nsim = len(ymt)
+    xdata = range(Nsim)
+    
+    # Extract columns and update lines directly
+    line1.set_data(xdata, [x[0].item() for x in ymt])
+    line2.set_data(xdata, [x[1].item() for x in ymt])
+    
+    for ax in (ax1, ax2):
+        ax.relim()
+        ax.autoscale_view()
+
+    plt.pause(0.001) # Render update
+
+logging.info(f"retry={concore.retrycount}")
 
 #################
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-ym2 = [x[1].item() for x in ymt]
-Nsim = len(ym1)
-
-plt.figure()
-plt.subplot(211)
-plt.plot(range(Nsim), ym1)
-plt.ylabel('MAP (mmHg)')
-plt.legend(['MAP'], loc=0)
-plt.subplot(212)
-plt.plot(range(Nsim), ym2)
-plt.xlabel('Cycles')
-plt.ylabel('HR (bpm)')
-plt.legend(['HR'], loc=0)
+# Final Save & cleanup
+plt.ioff()
 plt.savefig("hrmap.pdf")
 plt.show()

--- a/ratc/pmcvxpymatcore.py
+++ b/ratc/pmcvxpymatcore.py
@@ -76,11 +76,10 @@ print(u)
 # initialize controller constant and variables
 #Nsim =  150                          # number of simulation cycles
 concore.default_maxtime(150)
-#xc = np.zeros((X['Nx'], 1))          # initial conditon of state in MPC
-#Pd = X['Pd']                         # variance of initial state
-# set list to record inputs and outputs
-#ut = []
-#ymt = []
+
+# set list to record inputs and outputs for plotting
+ut = []
+ymt = []
 
 X = Get_MPC_Constants()
 print("initial plant")
@@ -93,6 +92,32 @@ concore.delay = 0.02
 init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 
+# --- LIVE PLOT SETUP ---
+plt.ion() # Enable interactive mode
+
+# 1. Setup hrmap figure (Outputs)
+fig_ym, (ax_map, ax_hr) = plt.subplots(2, 1)
+line_map_m, = ax_map.plot([], [], label='MAPm')
+ax_map.set_ylabel('MAP (mmHg)')
+ax_map.legend(loc=0)
+
+line_hr_m, = ax_hr.plot([], [], label='HRm')
+ax_hr.set_xlabel('Cycles')
+ax_hr.set_ylabel('HR (bpm)')
+ax_hr.legend(loc=0)
+
+# 2. Setup stim figure (Inputs)
+fig_u, axs_u = plt.subplots(3, 2)
+lines_u = []
+labels_u = ['Pw1 (s)', 'Pf1 (Hz)', 'Pw2 (s)', 'Pf2 (Hz)', 'Pw3 (s)', 'Pf3 (Hz)']
+for i, ax in enumerate(axs_u.flat):
+    line, = ax.plot([], [])
+    ax.set_ylabel(labels_u[i])
+    if i >= 4: ax.set_xlabel('Cycles')
+    lines_u.append((ax, line))
+fig_u.tight_layout()
+# ------------------------
+
 ym = np.array([concore.initval(init_simtime_ym)]).T
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
@@ -101,8 +126,37 @@ while(concore.simtime<concore.maxtime):
     print(u)
     #####
     xm, ym = Plant(u, xm, X)
+    
+    # Store history for plotting
+    ut.append(list(u.T[0]))
+    ymt.append(list(ym.T[0]))
     #####
+    
+    # --- LIVE UPDATE ---
+    Nsim = len(ymt)
+    xdata = range(Nsim)
+    
+    # Update Outputs (ym)
+    line_map_m.set_data(xdata, [x[0] for x in ymt])
+    line_hr_m.set_data(xdata, [x[1] for x in ymt])
+    for ax in (ax_map, ax_hr):
+        ax.relim()
+        ax.autoscale_view()
+        
+    # Update Inputs (u)
+    for i, (ax, line) in enumerate(lines_u):
+        line.set_data(xdata, [x[i] for x in ut])
+        ax.relim()
+        ax.autoscale_view()
+
+    plt.pause(0.001) # Render updates
+    # -------------------
+    
     print("ym="+str(ym)+" u="+str(u));
     concore.write(1,"ym",list(ym.T[0]),delta=1)
-#concore.write(1,"ym",init_simtime_ym)
+
 print("retry="+str(concore.retrycount))
+
+# --- FINAL CLEANUP ---
+plt.ioff()
+plt.show() # Keep plot open at the end

--- a/ratc/pmsid.py
+++ b/ratc/pmsid.py
@@ -244,63 +244,6 @@ class cardiac(constant):
         E_lv = self.E(x_tot[:, 9], x_tot[:, 10], x_tot[:, 6], x_tot[:, 7])       
         return t_tot, x_tot, E_lv, MHR_tot, MAP_tot
     
-    def model_plot(self, t_tot, x_tot, E_lv, MHR_tot, MAP_tot, Nsim, uc):
-        # Input variables
-        fig, ax = plt.subplots(3,2, figsize=(10,10))
-        ax[0,0].plot(uc[:,0])
-        ax[0,0].set(xlabel="Cardiac Cycle", ylabel="P_w (s)")
-        
-        ax[0,1].plot(uc[:,1])
-        ax[0,1].set(xlabel="Cardiac Cycle", ylabel="P_f (Hz)")
-        
-        ax[1,0].plot(uc[:,2])
-        ax[1,0].set(xlabel="Cardiac Cycle", ylabel="P_w (s)")
-        
-        ax[1,1].plot(uc[:,3])
-        ax[1,1].set(xlabel="Cardiac Cycle", ylabel="P_f (Hz)")
-        
-        ax[2,0].plot(uc[:,4])
-        ax[2,0].set(xlabel="Cardiac Cycle", ylabel="P_w (s)")
-    
-        ax[2,1].plot(uc[:,5])
-        ax[2,1].set(xlabel="Cardiac Cycle", ylabel="P_f (Hz)") 
-        plt.show()
-        
-        # Time course of MAP and HR
-        fig, ax = plt.subplots(2,1, figsize=(10, 10))
-        ax[0].plot(MAP_tot, 'o')
-        ax[0].set(xlabel="Cardiac Cycle", ylabel="MAP (mmHg)")
-        ax[1].plot(MHR_tot, 'o')
-        ax[1].set(xlabel="Cardiac cycle", ylabel="HR (bpm)")
-        plt.show()
-        
-        # Time course of left ventricular Elastance
-        fig, ax = plt.subplots(1,2, figsize=(10,10))
-        ax[0].plot(t_tot, E_lv)
-        ax[0].set(xlabel="t (s)", ylabel="E_{LV} (mmHg/mm^3)")
-        # Pressure-volume relationship of LV
-        ax[1].plot(x_tot[:, 0] + 50, E_lv*x_tot[:, 0])
-        ax[1].set(xlabel="Volume (mm^3)", ylabel="Pressure (mmHg)")
-        plt.show()
-        
-        # Time course of LV, Vein and arterial pressure
-        plt.plot(t_tot, E_lv*x_tot[:, 0])
-        plt.plot(t_tot, x_tot[:, 1])
-        plt.plot(t_tot, x_tot[:, 2])
-        plt.legend(['LV','Vein','Artery'])
-        plt.xlabel('t (s)')
-        plt.ylabel('Pressure (mmHg)')
-        plt.show()
-        
-        # Time course of systemic resistance
-        fig, ax = plt.subplots(1,2, figsize=(10,10))
-        ax[0].plot(t_tot, x_tot[:, 8])
-        ax[0].set(xlabel="t (s)", ylabel="R_{sys} (mmHg*s/mm^3)")
-        # Time course of maximum elastance of LV
-        ax[1].plot(t_tot, x_tot[:, 9])
-        ax[1].set(xlabel="t (s)", ylabel="E_{max} (mmHg/mm^3)")
-        plt.show()
-        
     def save_data(self, data):
         np.savetxt("{}.dat".format(data), data)
 
@@ -318,18 +261,75 @@ concore.delay = 0.02
 init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 
+# --- LIVE PLOT SETUP ---
+plt.ion() # Enable interactive mode
+
+# Setup hrmap figure (Outputs)
+fig_ym, (ax_map, ax_hr) = plt.subplots(2, 1)
+line_map, = ax_map.plot([], [], label='MAPm')
+ax_map.set_ylabel('MAP (mmHg)')
+ax_map.legend(loc=0)
+
+line_hr, = ax_hr.plot([], [], label='HRm')
+ax_hr.set_xlabel('Cycles')
+ax_hr.set_ylabel('HR (bpm)')
+ax_hr.legend(loc=0)
+
+# Setup stim figure (Inputs)
+fig_u, axs_u = plt.subplots(3, 2)
+lines_u = []
+labels_u = ['Pw1 (s)', 'Pf1 (Hz)', 'Pw2 (s)', 'Pf2 (Hz)', 'Pw3 (s)', 'Pf3 (Hz)']
+for i, ax in enumerate(axs_u.flat):
+    line, = ax.plot([], [])
+    ax.set_ylabel(labels_u[i])
+    if i >= 4: ax.set_xlabel('Cycles')
+    lines_u.append(line)
+fig_u.tight_layout()
+
+# Storage arrays for live plotting
+map_hist = []
+mhr_hist = []
+u_hist = []
+# ------------------------
+
 ym = np.array([concore.initval(init_simtime_ym)]).T
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         u = concore.read(1,"u",init_simtime_u)
     u = np.array(u).reshape(1, -1) #needs to be numpy col vect
+    
     ###### Solve odes
     t_tot, x_tot, E_lv, MHR, MAP  = cm.Cardiac_model(u, pl, 1, xm)
     xm = np.array(x_tot[-1])
     ym = [MAP[0],MHR[0]]  #already a python list
     #####
+    
+    # --- LIVE UPDATE ---
+    map_hist.append(MAP[0])
+    mhr_hist.append(MHR[0])
+    u_hist.append(u.flatten())
+    xdata = range(len(map_hist))
+    
+    # Update Outputs
+    line_map.set_data(xdata, map_hist)
+    line_hr.set_data(xdata, mhr_hist)
+    for ax in (ax_map, ax_hr):
+        ax.relim()
+        ax.autoscale_view()
+        
+    # Update Inputs
+    for i, line in enumerate(lines_u):
+        line.set_data(xdata, [x[i] for x in u_hist])
+        line.axes.relim()
+        line.axes.autoscale_view()
+        
+    plt.pause(0.001) # Render updates
+    # -------------------
+
     print("ym="+str(ym)+" u="+str(u));
     concore.write(1,"ym",ym,delta=1)
 print("retry="+str(concore.retrycount))
 
-
+# --- FINAL CLEANUP ---
+plt.ioff()
+plt.show() # Keep plot open at the end

--- a/ratc2/plotu.py
+++ b/ratc2/plotu.py
@@ -1,8 +1,9 @@
 import concore
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-print("plot u")
+logging.info("plot u")
 
 concore.delay = 0.005
 concore.default_maxtime(150)
@@ -10,49 +11,59 @@ init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 ut = []
 ymt = []
+
+plt.ion()       #interactive plotting
+plt.figure()    #initialize the figure before the loop
+
 u = concore.initval(init_simtime_u)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         u = concore.read(1,"u",init_simtime_u)
     concore.write(1,"u",u)
-    print("u="+str(u))
+    logging.debug(f"u={u}")
     ut.append(np.array(u).T)
-print("retry="+str(concore.retrycount))
 
-#################
+    #update plot every 5 cycles to prevent drawing lag
+    if len(ut) % 5 == 0: 
+        plt.clf() # clear the figure to draw the fresh frame
 
-# plot inputs and outputs
-u1 = [x[0].item() for x in ut]
-u2 = [x[1].item() for x in ut]
-u3 = [x[2].item() for x in ut]
-u4 = [x[3].item() for x in ut]
-u5 = [x[4].item() for x in ut]
-u6 = [x[5].item() for x in ut]
+        u1 = [x[0].item() for x in ut]
+        u2 = [x[1].item() for x in ut]
+        u3 = [x[2].item() for x in ut]
+        u4 = [x[3].item() for x in ut]
+        u5 = [x[4].item() for x in ut]
+        u6 = [x[5].item() for x in ut]
 
-Nsim = len(u1)
-plt.figure()
-plt.subplot(321)
-plt.plot(range(Nsim), u1)
-plt.ylabel('Pw1 (s)')
-plt.subplot(322)
-plt.plot(range(Nsim), u2)
-plt.ylabel('Pf1 (Hz)')
-plt.subplot(323)
-plt.plot(range(Nsim), u3)
-plt.xlabel('Cycles')
-plt.ylabel('Pw2 (s)')
-plt.subplot(324)
-plt.plot(range(Nsim), u4)
-plt.ylabel('Pf2 (Hz)')
-plt.subplot(325)
-plt.plot(range(Nsim), u5)
-plt.ylabel('Pw3 (s)')
-plt.subplot(326)
-plt.plot(range(Nsim), u6)
-plt.xlabel('Cycles')
-plt.ylabel('Pf3 (Hz)')
+        Nsim = len(u1)
+        plt.subplot(321)
+        plt.plot(range(Nsim), u1)
+        plt.ylabel('Pw1 (s)')
+        plt.subplot(322)
+        plt.plot(range(Nsim), u2)
+        plt.ylabel('Pf1 (Hz)')
+        plt.subplot(323)
+        plt.plot(range(Nsim), u3)
+        plt.xlabel('Cycles')
+        plt.ylabel('Pw2 (s)')
+        plt.subplot(324)
+        plt.plot(range(Nsim), u4)
+        plt.ylabel('Pf2 (Hz)')
+        plt.subplot(325)
+        plt.plot(range(Nsim), u5)
+        plt.ylabel('Pw3 (s)')
+        plt.subplot(326)
+        plt.plot(range(Nsim), u6)
+        plt.xlabel('Cycles')
+        plt.ylabel('Pf3 (Hz)')
+        plt.tight_layout()
+        
+        plt.pause(0.001)
+
+logging.info(f"retry={concore.retrycount}")
+
+#post-simulation cleanup
+plt.ioff()               
 plt.savefig("stim.pdf")
-plt.tight_layout()
 plt.show()
 
 

--- a/ratc2/plotym.py
+++ b/ratc2/plotym.py
@@ -1,8 +1,9 @@
 import concore
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-print("plot ym")
+logging.info("plot ym")
 
 concore.delay = 0.005
 concore.default_maxtime(150)
@@ -10,31 +11,45 @@ init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 ut = []
 ymt = []
+plt.ion() # Enable interactive mode
+fig, (ax1, ax2) = plt.subplots(2, 1)
+
+line1, = ax1.plot([], [])
+ax1.set_ylabel('MAP (mmHg)')
+ax1.legend(['MAP'], loc=0)
+
+line2, = ax2.plot([], [])
+ax2.set_xlabel('Cycles '+str(concore.params))
+ax2.set_ylabel('HR (bpm)')
+ax2.legend(['HR'], loc=0)
+
 ym = concore.initval(init_simtime_ym)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         ym = concore.read(1,"ym",init_simtime_ym)
     concore.write(1,"ym",ym)
-    print(" ym="+str(ym))
+    logging.debug(f" ym={ym}")
     ymt.append(np.array(ym).T)
-print("retry="+str(concore.retrycount))
+
+    #real-time update
+    Nsim = len(ymt)
+    xdata = range(Nsim)
+    
+    # Extract columns and update lines directly
+    line1.set_data(xdata, [x[0].item() for x in ymt])
+    line2.set_data(xdata, [x[1].item() for x in ymt])
+    
+    for ax in (ax1, ax2):
+        ax.relim()
+        ax.autoscale_view()
+
+    plt.pause(0.001) # Render update
+
+logging.info(f"retry={concore.retrycount}")
 
 #################
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-ym2 = [x[1].item() for x in ymt]
-Nsim = len(ym1)
-
-plt.figure()
-plt.subplot(211)
-plt.plot(range(Nsim), ym1)
-plt.ylabel('MAP (mmHg)')
-plt.legend(['MAP'], loc=0)
-plt.subplot(212)
-plt.plot(range(Nsim), ym2)
-plt.xlabel('Cycles')
-plt.ylabel('HR (bpm)')
-plt.legend(['HR'], loc=0)
+# Final Save & cleanup
+plt.ioff()
 plt.savefig("hrmap.pdf")
 plt.show()

--- a/tools/plotu.py
+++ b/tools/plotu.py
@@ -11,6 +11,10 @@ init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 ut = []
 ymt = []
+
+plt.ion()       #interactive plotting
+plt.figure()    #initialize the figure before the loop
+
 u = concore.initval(init_simtime_u)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
@@ -18,42 +22,48 @@ while(concore.simtime<concore.maxtime):
     concore.write(1,"u",u)
     logging.debug(f"u={u}")
     ut.append(np.array(u).T)
+
+    #update plot every 5 cycles to prevent drawing lag
+    if len(ut) % 5 == 0: 
+        plt.clf() # clear the figure to draw the fresh frame
+
+        u1 = [x[0].item() for x in ut]
+        u2 = [x[1].item() for x in ut]
+        u3 = [x[2].item() for x in ut]
+        u4 = [x[3].item() for x in ut]
+        u5 = [x[4].item() for x in ut]
+        u6 = [x[5].item() for x in ut]
+
+        Nsim = len(u1)
+        plt.subplot(321)
+        plt.plot(range(Nsim), u1)
+        plt.ylabel('Pw1 (s)')
+        plt.subplot(322)
+        plt.plot(range(Nsim), u2)
+        plt.ylabel('Pf1 (Hz)')
+        plt.subplot(323)
+        plt.plot(range(Nsim), u3)
+        plt.xlabel('Cycles')
+        plt.ylabel('Pw2 (s)')
+        plt.subplot(324)
+        plt.plot(range(Nsim), u4)
+        plt.ylabel('Pf2 (Hz)')
+        plt.subplot(325)
+        plt.plot(range(Nsim), u5)
+        plt.ylabel('Pw3 (s)')
+        plt.subplot(326)
+        plt.plot(range(Nsim), u6)
+        plt.xlabel('Cycles')
+        plt.ylabel('Pf3 (Hz)')
+        plt.tight_layout()
+        
+        plt.pause(0.001)
+
 logging.info(f"retry={concore.retrycount}")
 
-#################
-
-# plot inputs and outputs
-u1 = [x[0].item() for x in ut]
-u2 = [x[1].item() for x in ut]
-u3 = [x[2].item() for x in ut]
-u4 = [x[3].item() for x in ut]
-u5 = [x[4].item() for x in ut]
-u6 = [x[5].item() for x in ut]
-
-Nsim = len(u1)
-plt.figure()
-plt.subplot(321)
-plt.plot(range(Nsim), u1)
-plt.ylabel('Pw1 (s)')
-plt.subplot(322)
-plt.plot(range(Nsim), u2)
-plt.ylabel('Pf1 (Hz)')
-plt.subplot(323)
-plt.plot(range(Nsim), u3)
-plt.xlabel('Cycles')
-plt.ylabel('Pw2 (s)')
-plt.subplot(324)
-plt.plot(range(Nsim), u4)
-plt.ylabel('Pf2 (Hz)')
-plt.subplot(325)
-plt.plot(range(Nsim), u5)
-plt.ylabel('Pw3 (s)')
-plt.subplot(326)
-plt.plot(range(Nsim), u6)
-plt.xlabel('Cycles')
-plt.ylabel('Pf3 (Hz)')
+#post-simulation cleanup
+plt.ioff()               
 plt.savefig("stim.pdf")
-plt.tight_layout()
 plt.show()
 
 

--- a/tools/plotym.py
+++ b/tools/plotym.py
@@ -11,6 +11,18 @@ init_simtime_u = "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
 init_simtime_ym = "[0.0, 0.0, 0.0]"
 ut = []
 ymt = []
+plt.ion() # Enable interactive mode
+fig, (ax1, ax2) = plt.subplots(2, 1)
+
+line1, = ax1.plot([], [])
+ax1.set_ylabel('MAP (mmHg)')
+ax1.legend(['MAP'], loc=0)
+
+line2, = ax2.plot([], [])
+ax2.set_xlabel('Cycles '+str(concore.params))
+ax2.set_ylabel('HR (bpm)')
+ax2.legend(['HR'], loc=0)
+
 ym = concore.initval(init_simtime_ym)
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
@@ -18,24 +30,26 @@ while(concore.simtime<concore.maxtime):
     concore.write(1,"ym",ym)
     logging.debug(f" ym={ym}")
     ymt.append(np.array(ym).T)
+
+    #real-time update
+    Nsim = len(ymt)
+    xdata = range(Nsim)
+    
+    # Extract columns and update lines directly
+    line1.set_data(xdata, [x[0].item() for x in ymt])
+    line2.set_data(xdata, [x[1].item() for x in ymt])
+    
+    for ax in (ax1, ax2):
+        ax.relim()
+        ax.autoscale_view()
+
+    plt.pause(0.001) # Render update
+
 logging.info(f"retry={concore.retrycount}")
 
 #################
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-ym2 = [x[1].item() for x in ymt]
-Nsim = len(ym1)
-
-plt.figure()
-plt.subplot(211)
-plt.plot(range(Nsim), ym1)
-plt.ylabel('MAP (mmHg)')
-plt.legend(['MAP'], loc=0)
-plt.subplot(212)
-plt.plot(range(Nsim), ym2)
-plt.xlabel('Cycles '+str(concore.params))
-plt.ylabel('HR (bpm)')
-plt.legend(['HR'], loc=0)
+# Final Save & cleanup
+plt.ioff()
 plt.savefig("hrmap.pdf")
 plt.show()

--- a/tools/plotymlag.py
+++ b/tools/plotymlag.py
@@ -16,8 +16,21 @@ ut = []
 ymt = []
 ym = []
 for i in range(0,size):
-   ym.append(concore.initval(init_simtime_ym))
+    ym.append(concore.initval(init_simtime_ym))
 cur = 0
+
+plt.ion() # enable interactive mode
+fig, (ax1, ax2) = plt.subplots(2, 1)
+
+line1, = ax1.plot([], [])
+ax1.set_ylabel('MAP (mmHg)')
+ax1.legend(['MAP'], loc=0)
+
+line2, = ax2.plot([], [])
+ax2.set_xlabel('Cycles '+str(concore.params))
+ax2.set_ylabel('HR (bpm)')
+ax2.legend(['HR'], loc=0)
+
 while(concore.simtime<concore.maxtime):
     while concore.unchanged():
         ym[cur] = concore.read(1,"ym",init_simtime_ym)
@@ -25,24 +38,26 @@ while(concore.simtime<concore.maxtime):
     logging.debug(f" ym={ym[cur]}")
     ymt.append(np.array(ym[(cur-lag) % size]).T)
     cur = (cur+1) % size
+
+    #real-time update
+    Nsim = len(ymt)
+    xdata = range(Nsim)
+    
+    #extract columns and update lines directly with lagged data
+    line1.set_data(xdata, [x[0].item() for x in ymt])
+    line2.set_data(xdata, [x[1].item() for x in ymt])
+    
+    for ax in (ax1, ax2):
+        ax.relim()
+        ax.autoscale_view()
+
+    plt.pause(0.001) # Render update
+
 logging.info(f"retry={concore.retrycount}")
 
 #################
 
-# plot inputs and outputs
-ym1 = [x[0].item() for x in ymt]
-ym2 = [x[1].item() for x in ymt]
-Nsim = len(ym1)
-
-plt.figure()
-plt.subplot(211)
-plt.plot(range(Nsim), ym1)
-plt.ylabel('MAP (mmHg)')
-plt.legend(['MAP'], loc=0)
-plt.subplot(212)
-plt.plot(range(Nsim), ym2)
-plt.xlabel('Cycles '+str(concore.params))
-plt.ylabel('HR (bpm)')
-plt.legend(['HR'], loc=0)
+# Final Save & cleanup
+plt.ioff()
 plt.savefig("hrmap.pdf")
 plt.show()


### PR DESCRIPTION
- I have replaced the previous blocking behavior where plots were only generated at the very end of a simulation cycle with real-time, live-updating visualizations across the simulation
**(please take a look on the video as it could be interesting)**

My motive behind this big change was:

- In real-world applications (such as simulating a pacemaker system or observing prolonged physiological responses), waiting for an entire 1000+ cycle simulation to finish before seeing the results is impractical. Users and researchers need to visually monitor system stability, inputs (u), and outputs (ym) dynamically as the simulation runs.
- Furthermore, as we prepare for simulations with heavier computational workloads and longer runtimes (e.g., upcoming Julia implementations), having live feedback is critical for monitoring system behavior without waiting for complete execution.

@pradeeban I have done the implementation as we discussed yesterday, while doing that I have discovered that some of the ratc study simulation weren't running properly because of python version (the older version of python were a little linent in terms of math bugs, but newer python is a little stricter, this is causing some kind of value error when debugging some of the graphs especially the **yuyu-series** graphs.

I believe that we should avoid touching actual code for the simulation as of right now as it contains our legacy studies and doing even a small mistake in fixing the actual simulation can worsen the problem.

In this PR I have just changed the logic of how matplotlib is plotting graph.

This fixes #445 .

https://github.com/user-attachments/assets/8f9b33ae-3838-483e-962c-8a4318ad23bd