### PR TITLE
 fix: packaging broken install and version duplication 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ ENV/
 .vscode/
 .idea/
 
+# Build/packaging
+*.egg-info/
+dist/
+build/
+
 # Testing
 .pytest_cache/
 htmlcov/

--- a/concore_cli/__init__.py
+++ b/concore_cli/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "1.0.0"
+
 from .cli import cli
 
 __all__ = ['cli']

--- a/concore_cli/cli.py
+++ b/concore_cli/cli.py
@@ -10,12 +10,13 @@ from .commands.status import show_status
 from .commands.stop import stop_all
 from .commands.inspect import inspect_workflow
 from .commands.watch import watch_study
+from . import __version__
 
 console = Console()
 DEFAULT_EXEC_TYPE = 'windows' if os.name == 'nt' else 'posix'
 
 @click.group()
-@click.version_option(version='1.0.0', prog_name='concore')
+@click.version_option(version=__version__, prog_name='concore')
 def cli():
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "concore"
-version = "1.0.0"
+dynamic = ["version"]
 description = "Concore workflow management CLI"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -17,8 +17,6 @@ dependencies = [
     "psutil>=5.8.0",
     "numpy>=1.19.0",
     "pyzmq>=22.0.0",
-    "scipy>=1.5.0",
-    "matplotlib>=3.3.0",
 ]
 
 [project.optional-dependencies]
@@ -26,10 +24,17 @@ dev = [
     "pytest>=6.0.0",
     "pytest-cov>=2.10.0",
 ]
+demo = [
+    "scipy>=1.5.0",
+    "matplotlib>=3.3.0",
+]
 
 [project.scripts]
 concore = "concore_cli.cli:cli"
 
 [tool.setuptools]
 packages = ["concore_cli", "concore_cli.commands"]
-py-modules = ["mkconcore"]
+py-modules = ["concore", "concoredocker", "concore_base", "mkconcore"]
+
+[tool.setuptools.dynamic]
+version = {attr = "concore_cli.__version__"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
 beautifulsoup4
 lxml
-tensorflow
 numpy
 pyzmq
 scipy
 matplotlib
-cvxopt
-PyGithub
 click>=8.0.0
 rich>=10.0.0
 psutil>=5.8.0

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
-
-setup(
-    name="concore",
-    version="1.0.0",
-    author="ControlCore Project",
-    description="A command-line interface for concore neuromodulation workflows",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/ControlCore-Project/concore",
-    packages=find_packages(),
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-    ],
-    python_requires=">=3.9",
-    install_requires=[
-        "beautifulsoup4",
-        "lxml",
-        "numpy",
-        "pyzmq",
-        "scipy",
-        "matplotlib",
-        "click>=8.0.0",
-        "rich>=10.0.0",
-        "psutil>=5.8.0",
-    ],
-    entry_points={
-        "console_scripts": [
-            "concore=concore_cli.cli:cli",
-        ],
-    },
-)
+# All metadata and configuration is in pyproject.toml.
+# This file exists only for legacy compatibility.
+setup()


### PR DESCRIPTION
fixes #437

fixes the broken install 



- added missing py-modules (concore, concoredocker, concore_base)
- version now in [concore_cli.__version__](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), not hardcoded twice
- scipy/matplotlib → optional [demo], pulled tensorflow/cvxopt/PyGithub out of [requirements.txt](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [setup.py](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is a shim now

96 tests pass

<img width="436" height="243" alt="image" src="https://github.com/user-attachments/assets/93b5245a-a197-4fdb-b3ac-0122c85d5366" />


