### PR TITLE
test: Add cross runtime protocol conformance matrix (Phase 2)

### DIFF
--- a/tests/protocol_fixtures/PROTOCOL_FIXTURES.md
+++ b/tests/protocol_fixtures/PROTOCOL_FIXTURES.md
@@ -4,9 +4,16 @@ This directory contains the phase-1 protocol conformance baseline for Python.
 
 - `schema.phase1.json`: fixture document shape and supported case targets.
 - `python_phase1_cases.json`: initial baseline cases (report-only mode metadata).
+- `cross_runtime_matrix.phase2.json`: phase-2 cross-runtime mapping matrix in report-only mode.
 
 Phase-1 scope:
 
 - No runtime behavior changes.
 - Python-only execution through `tests/test_protocol_conformance.py`.
 - Fixture format is language-neutral to enable future cross-binding runners.
+
+Phase-2 scope (mapping only):
+
+- No runtime behavior changes.
+- Adds a cross-runtime matrix to track per-case audit status and classification.
+- Keeps CI non-blocking for non-Python runtimes by marking them as `not_audited` until adapters are added.

--- a/tests/protocol_fixtures/cross_runtime_matrix.phase2.json
+++ b/tests/protocol_fixtures/cross_runtime_matrix.phase2.json
@@ -1,0 +1,211 @@
+{
+  "schema_version": "1.0",
+  "phase": "2",
+  "mode": "report_only",
+  "source_fixture": "python_phase1_cases.json",
+  "runtimes": [
+    "python",
+    "cpp",
+    "matlab",
+    "octave",
+    "verilog"
+  ],
+  "classifications": [
+    "required",
+    "implementation_defined",
+    "known_deviation"
+  ],
+  "statuses": [
+    "observed_pass",
+    "observed_fail",
+    "not_audited"
+  ],
+  "cases": [
+    {
+      "id": "parse_params/simple_types_and_whitespace",
+      "target": "parse_params",
+      "runtime_results": {
+        "python": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Phase-1 baseline execution."
+        },
+        "cpp": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "matlab": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "octave": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "verilog": {
+          "status": "not_audited",
+          "classification": "implementation_defined",
+          "note": "May require binding-specific interpretation."
+        }
+      }
+    },
+    {
+      "id": "parse_params/embedded_equals_not_split",
+      "target": "parse_params",
+      "runtime_results": {
+        "python": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Phase-1 baseline execution."
+        },
+        "cpp": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "matlab": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "octave": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "verilog": {
+          "status": "not_audited",
+          "classification": "implementation_defined",
+          "note": "May require binding-specific interpretation."
+        }
+      }
+    },
+    {
+      "id": "initval/valid_list_sets_simtime",
+      "target": "initval",
+      "runtime_results": {
+        "python": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Phase-1 baseline execution."
+        },
+        "cpp": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "matlab": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "octave": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "verilog": {
+          "status": "not_audited",
+          "classification": "implementation_defined",
+          "note": "May require binding-specific interpretation."
+        }
+      }
+    },
+    {
+      "id": "initval/invalid_input_returns_empty_and_preserves_simtime",
+      "target": "initval",
+      "runtime_results": {
+        "python": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Phase-1 baseline execution."
+        },
+        "cpp": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "matlab": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "octave": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "verilog": {
+          "status": "not_audited",
+          "classification": "implementation_defined",
+          "note": "May require binding-specific interpretation."
+        }
+      }
+    },
+    {
+      "id": "write_zmq/list_payload_prepends_timestamp_without_mutation",
+      "target": "write_zmq",
+      "runtime_results": {
+        "python": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Phase-1 baseline execution."
+        },
+        "cpp": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "matlab": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "octave": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "verilog": {
+          "status": "not_audited",
+          "classification": "implementation_defined",
+          "note": "May require binding-specific interpretation."
+        }
+      }
+    },
+    {
+      "id": "write_zmq/non_list_payload_forwarded_as_is",
+      "target": "write_zmq",
+      "runtime_results": {
+        "python": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Phase-1 baseline execution."
+        },
+        "cpp": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "matlab": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "octave": {
+          "status": "not_audited",
+          "classification": "required",
+          "note": "Audit planned in phase 2."
+        },
+        "verilog": {
+          "status": "not_audited",
+          "classification": "implementation_defined",
+          "note": "May require binding-specific interpretation."
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_protocol_conformance_phase2.py
+++ b/tests/test_protocol_conformance_phase2.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "protocol_fixtures"
+PHASE1_CASES_PATH = FIXTURE_DIR / "python_phase1_cases.json"
+PHASE2_MATRIX_PATH = FIXTURE_DIR / "cross_runtime_matrix.phase2.json"
+
+EXPECTED_RUNTIMES = {"python", "cpp", "matlab", "octave", "verilog"}
+EXPECTED_CLASSIFICATIONS = {"required", "implementation_defined", "known_deviation"}
+EXPECTED_STATUSES = {"observed_pass", "observed_fail", "not_audited"}
+
+
+def _load_json(path):
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _phase1_cases():
+    doc = _load_json(PHASE1_CASES_PATH)
+    return {case["id"]: case for case in doc["cases"]}
+
+
+def _phase2_matrix():
+    return _load_json(PHASE2_MATRIX_PATH)
+
+
+def test_phase2_matrix_metadata_and_enums():
+    doc = _phase2_matrix()
+    assert doc["phase"] == "2"
+    assert doc["mode"] == "report_only"
+    assert doc["source_fixture"] == "python_phase1_cases.json"
+    assert set(doc["runtimes"]) == EXPECTED_RUNTIMES
+    assert set(doc["classifications"]) == EXPECTED_CLASSIFICATIONS
+    assert set(doc["statuses"]) == EXPECTED_STATUSES
+
+
+def test_phase2_matrix_covers_all_phase1_cases():
+    phase1 = _phase1_cases()
+    matrix_cases = _phase2_matrix()["cases"]
+    matrix_ids = {case["id"] for case in matrix_cases}
+    assert matrix_ids == set(phase1.keys())
+
+
+def test_phase2_matrix_rows_have_consistent_shape():
+    phase1 = _phase1_cases()
+    for row in _phase2_matrix()["cases"]:
+        assert row["id"] in phase1
+        assert row["target"] == phase1[row["id"]]["target"]
+        assert set(row["runtime_results"].keys()) == EXPECTED_RUNTIMES
+
+        for runtime, result in row["runtime_results"].items():
+            assert result["status"] in EXPECTED_STATUSES
+            assert result["classification"] in EXPECTED_CLASSIFICATIONS
+            assert isinstance(result["note"], str) and result["note"].strip()
+            if runtime == "python":
+                assert result["status"] == "observed_pass"


### PR DESCRIPTION
Hi @pradeeban,
Following up on the discussion in #440 and Phase 1 conformance work, here is the PR for **Phase 2 (mapping/audit)**. 

As promised in our initial plan, this PR is strictly **report only and non breaking**. It introduces a language agnostic matrix to track how different runtimes handle the protocol cases we defined in Phase 1, without changing a single line of runtime logic anywhere.

## What Changed
* **The Matrix (`cross_runtime_matrix.phase2.json`):** Added phase 2 metadata (`phase`, `mode`, `runtimes`, `classifications`, `statuses`).
  * Mapped each Phase 1 case across `python`, `cpp`, `matlab`, `octave`, and `verilog`.
  * Crucially, all non Python runtimes are explicitly marked as `not_audited` to ensure this phase remains purely observational.
* **The Runner (`tests/test_protocol_conformance_phase2.py`):**
  * Validates the matrix metadata and enums.
  * Ensures a 1:1 mapping with Phase 1 case IDs.
  * Enforces row shape consistency and verifies the `python=observed_pass` baseline.
* **Documentation (`PROTOCOL_FIXTURES.md`):** Updated to clearly document the Phase 2 scope and constraints.

## Safety
* **Zero production/runtime files were modified.**  There are absolutely no behavior changes for any existing language bindings.
* We are not forcing cross-language behavior; this just adds the structured audit foundation so we can review the landscape before considering any future enforcement.

## Validation
* Targeted conformance tests:
  `python -m pytest -v tests/test_protocol_conformance.py tests/test_protocol_conformance_phase2.py` → **10 passed**
* Broader non-regression run:
  `python -m pytest -v tests --ignore=tests/test_openjupyter_security.py` → **99 passed**

## Evidence
### 1) Phase-2 matrix metadata (report only + enums)
<img width="1482" height="214" alt="Screenshot 2026-02-25 011743" src="https://github.com/user-attachments/assets/08a0b709-8221-41ec-b71c-7e1faa42683c" />

### 2) Example mapped case (Python observed, others pending)
<img width="738" height="759" alt="Screenshot 2026-02-25 013418" src="https://github.com/user-attachments/assets/17924023-3812-4652-9016-186d2adb8779" />

### 3) Targeted conformance tests passing
<img width="1476" height="648" alt="Screenshot 2026-02-25 011859" src="https://github.com/user-attachments/assets/accd5d04-59ef-4c49-8bd6-ad0c17f216d8" />

### 4) Broader test run passing
<img width="1474" height="669" alt="Screenshot 2026-02-25 011936" src="https://github.com/user-attachments/assets/1435508c-8c0f-4a43-b6b7-518384545ee2" />


## Note to Maintainers
I kept this intentionally minimal and report only so we can review the matrix structure together before we start classifying how the other languages currently behave. let me know if this structure looks good to you.