### PR TITLE
feat: add ZMQ support to concoredocker.hpp

### DIFF
--- a/concoredocker.hpp
+++ b/concoredocker.hpp
@@ -231,7 +231,7 @@ public:
         }
         val.insert(val.begin(), simtime + delta);
         it->second->send_with_retry(val);
-        // simtime must not be mutated here (issue #385).
+        // simtime must not be mutated here.
     }
 
     std::vector<double> read(const std::string& port_name, const std::string& name, const std::string& initstr) {


### PR DESCRIPTION
#475 added ZMQ to [concore.hpp](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [concoredocker.hpp](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) still file-only. Same pattern, [zmq_ports](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), `init_zmq_port`, [read_ZMQ](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[write_ZMQ](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), string-port overloads, guarded by [CONCORE_USE_ZMQ](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

also fixed read()/write()/initval() returning [vector<string>](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [vector<double>](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), makes wire types consistent across both C++ variants.

closes #480