### PR TITLE
Fix: Replace hardcoded 256-byte shared memory buffer with 4096-byte

### DIFF
--- a/concore.hpp
+++ b/concore.hpp
@@ -265,6 +265,20 @@ private:
 
         if (shmId_create == -1) {
             std::cerr << "Failed to create shared memory segment." << std::endl;
+            return;
+        }
+
+        // Verify the segment is large enough (shmget won't resize an existing segment)
+        struct shmid_ds shm_info;
+        if (shmctl(shmId_create, IPC_STAT, &shm_info) == 0 && shm_info.shm_segsz < SHM_SIZE) {
+            std::cerr << "Shared memory segment too small (" << shm_info.shm_segsz
+                      << " bytes, need " << SHM_SIZE << "). Removing and recreating." << std::endl;
+            shmctl(shmId_create, IPC_RMID, nullptr);
+            shmId_create = shmget(key, SHM_SIZE, IPC_CREAT | 0666);
+            if (shmId_create == -1) {
+                std::cerr << "Failed to recreate shared memory segment." << std::endl;
+                return;
+            }
         }
 
         // Attach the shared memory segment to the process's address space
@@ -660,6 +674,8 @@ private:
         try {
             std::ostringstream outfile;
             if(shmId_create != -1){
+                if (sharedData_create == nullptr)
+                    throw 506;
                 val.insert(val.begin(),simtime+delta);
                 outfile<<'[';
                 for(int i=0;i<val.size()-1;i++)
@@ -697,6 +713,8 @@ private:
         this_thread::sleep_for(timespan);
         try {
             if(shmId_create != -1){
+                if (sharedData_create == nullptr)
+                    throw 506;
                 if (val.size() >= SHM_SIZE) {
                     std::cerr << "ERROR: write_SM payload (" << val.size()
                               << " bytes) exceeds " << SHM_SIZE - 1

--- a/concoredocker.hpp
+++ b/concoredocker.hpp
@@ -240,6 +240,20 @@ public:
             std::cerr << "Failed to create shared memory segment.\n";
             return;
         }
+
+        // Verify the segment is large enough (shmget won't resize an existing segment)
+        struct shmid_ds shm_info;
+        if (shmctl(shmId_create, IPC_STAT, &shm_info) == 0 && shm_info.shm_segsz < SHM_SIZE) {
+            std::cerr << "Shared memory segment too small (" << shm_info.shm_segsz
+                      << " bytes, need " << SHM_SIZE << "). Removing and recreating.\n";
+            shmctl(shmId_create, IPC_RMID, nullptr);
+            shmId_create = shmget(key, SHM_SIZE, IPC_CREAT | 0666);
+            if (shmId_create == -1) {
+                std::cerr << "Failed to recreate shared memory segment.\n";
+                return;
+            }
+        }
+
         sharedData_create = static_cast<char*>(shmat(shmId_create, NULL, 0));
         if (sharedData_create == reinterpret_cast<char*>(-1)) {
             std::cerr << "Failed to attach shared memory segment.\n";
@@ -421,6 +435,8 @@ public:
         try {
             if (shmId_create == -1)
                 throw 505;
+            if (sharedData_create == nullptr)
+                throw 506;
             val.insert(val.begin(), simtime + delta);
             std::ostringstream outfile;
             outfile << '[';


### PR DESCRIPTION
The C++ shared memory implementation in `concore.hpp` and `concoredocker.hpp` allocates a fixed 256-byte buffer for inter-node data exchange and silently truncates any payload exceeding 255 characters with no warning, no error, and no log output. Downstream nodes receive incomplete data and produce wrong results.

Closes #514

**Root Cause**
Three hardcoded `256` values across `shmget()`, `strncpy()`, and `strnlen()` calls limited the shared memory buffer to 256 bytes. The wire format `[simtime, val1, val2, ..., valN]` uses ~8–18 characters per double, so payloads with 25+ values silently overflow. This is a critical data corruption bug for realistic neuromodulation studies with 32+ sensor channels (EEG, multi-electrode arrays).

**Changes**
**In both `concore.hpp` and `concoredocker.hpp`:**
1. **Added `static constexpr size_t SHM_SIZE = 4096`** replaces all hardcoded `256` with a single named constant. Buffer now supports ~200+ double values (up from ~25).
2. **Replaced all hardcoded `256`** in:
   - `shmget(key, 256, ...)` → `shmget(key, SHM_SIZE, ...)`
   - `strnlen(sharedData_get, 256)` → `strnlen(sharedData_get, SHM_SIZE)`
   - `strncpy(sharedData_create, ..., 256 - 1)` → `strncpy(sharedData_create, ..., SHM_SIZE - 1)`
3. **Added overflow detection** in `write_SM()` prints a clear `stderr` error message when payload exceeds `SHM_SIZE`, instead of silently truncating.
4. **Added explicit null termination** `sharedData_create[SHM_SIZE - 1] = '\0'` after every `strncpy()` to prevent read overruns (defense-in-depth).

**Affected Files**
| File | Changes |
|------|---------|
| `concore.hpp` | `SHM_SIZE` constant + 7 replacements + 2 overflow checks + 2 null terminators |
| `concoredocker.hpp` | `SHM_SIZE` constant + 4 replacements + 1 overflow check + 1 null terminator |

> **Note:** `sample/src/concore.hpp` has the same issue but is not tracked in git. The fix pattern is identical and can be applied when that file is added to the repository.

**Testing**
- All 164 existing Python tests pass (`pytest tests/ -v` → 164 passed)
- C++ compilation verified on Windows (MinGW g++ 6.3.0) — shared memory code is `#ifdef __linux__` guarded, compiles cleanly
- Manual verification: 3000-byte payload fits without truncation (previously would have been silently cut at 255 bytes)

**Before / After**
| Scenario | Before (256 bytes) | After (4096 bytes) |
|----------|--------------------|--------------------|
| 10 doubles (~120 bytes) | Works | Works |
| 25 doubles (~280 bytes) | **Silently truncated** | Works |
| 50 doubles (~600 bytes) | **Silently truncated** | Works |
| 200 doubles (~2400 bytes) | **Silently truncated** | Works |
| >200 doubles (>4095 bytes) | **Silently truncated** | **Error message printed** + truncated |
