### PR TITLE
Rename CLI command run → build to reflect actual behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ concore init my-project
 # Validate your workflow
 concore validate workflow.graphml
 
-# Run your workflow
-concore run workflow.graphml --auto-build
+# Compile your workflow
+concore build workflow.graphml --auto-build
 
 # Monitor running processes
 concore status

--- a/concore_cli/README.md
+++ b/concore_cli/README.md
@@ -20,8 +20,8 @@ cd my-project
 # Validate your workflow
 concore validate workflow.graphml
 
-# Run your workflow
-concore run workflow.graphml
+# Build your workflow
+concore build workflow.graphml
 
 # Check running processes
 concore status
@@ -53,9 +53,9 @@ my-workflow/
 └── README.md          # Project documentation
 ```
 
-### `concore run <workflow_file>`
+### `concore build <workflow_file>`
 
-Generates and optionally builds a workflow from a GraphML file.
+Compiles a concore workflow GraphML file into executable scripts (POSIX, Windows, or Docker).
 
 **Options:**
 - `-s, --source <dir>` - Source directory (default: src)
@@ -66,13 +66,13 @@ Generates and optionally builds a workflow from a GraphML file.
 
 **Example:**
 ```bash
-concore run workflow.graphml --source ./src --output ./build --auto-build
+concore build workflow.graphml --source ./src --output ./build --auto-build
 ```
 
 Docker compose example:
 
 ```bash
-concore run workflow.graphml --source ./src --output ./out --type docker --compose
+concore build workflow.graphml --source ./src --output ./out --type docker --compose
 cd out
 docker compose up
 ```
@@ -150,7 +150,7 @@ concore stop
 
 5. **Generate and run**
    ```bash
-   concore run workflow.graphml --auto-build
+   concore build workflow.graphml --auto-build
    cd out
    ./run.bat  # or ./run on Linux/Mac
    ```

--- a/concore_cli/cli.py
+++ b/concore_cli/cli.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from .commands.init import init_project, init_project_interactive, run_wizard
-from .commands.run import run_workflow
+from .commands.build import build_workflow
 from .commands.validate import validate_workflow
 from .commands.status import show_status
 from .commands.stop import stop_all
@@ -68,17 +68,17 @@ def init(name, template, interactive):
     help="Execution type",
 )
 @click.option(
-    "--auto-build", is_flag=True, help="Automatically run build after generation"
+    "--auto-build", is_flag=True, help="Automatically run build script after generation"
 )
 @click.option(
     "--compose",
     is_flag=True,
     help="Generate docker-compose.yml in output directory (docker type only)",
 )
-def run(workflow_file, source, output, type, auto_build, compose):
-    """Run a concore workflow"""
+def build(workflow_file, source, output, type, auto_build, compose):
+    """Compile a concore workflow into executable scripts"""
     try:
-        run_workflow(
+        build_workflow(
             workflow_file,
             source,
             output,

--- a/concore_cli/commands/__init__.py
+++ b/concore_cli/commands/__init__.py
@@ -1,5 +1,5 @@
 from .init import init_project
-from .run import run_workflow
+from .build import build_workflow
 from .validate import validate_workflow
 from .status import show_status
 from .stop import stop_all
@@ -8,7 +8,7 @@ from .doctor import doctor_check
 
 __all__ = [
     "init_project",
-    "run_workflow",
+    "build_workflow",
     "validate_workflow",
     "show_status",
     "stop_all",

--- a/concore_cli/commands/build.py
+++ b/concore_cli/commands/build.py
@@ -115,7 +115,7 @@ def _write_docker_compose(output_path):
     return compose_path
 
 
-def run_workflow(
+def build_workflow(
     workflow_file,
     source,
     output,
@@ -201,7 +201,7 @@ def run_workflow(
             try:
                 metadata_path = write_study_metadata(
                     output_path,
-                    generated_by="concore run",
+                    generated_by="concore build",
                     workflow_file=workflow_path,
                 )
                 console.print(

--- a/concore_cli/commands/init.py
+++ b/concore_cli/commands/init.py
@@ -183,9 +183,9 @@ A concore workflow project.
 
 1. Edit your workflow in `workflow.graphml` using yEd or similar GraphML editor
 2. Add your processing scripts to the `src/` directory
-3. Run your workflow:
+3. Build your workflow:
    ```
-   concore run workflow.graphml
+   concore build workflow.graphml
    ```
 
 ## Project Structure
@@ -318,7 +318,7 @@ def init_project_interactive(name, selected_langs, console):
             f"Next steps:\n"
             f"  cd {name}\n"
             f"  concore validate workflow.graphml\n"
-            f"  concore run workflow.graphml",
+            f"  concore build workflow.graphml",
             title="Success",
             border_style="green",
         )
@@ -371,7 +371,7 @@ def init_project(name, template, console):
             f"Next steps:\n"
             f"  cd {name}\n"
             f"  concore validate workflow.graphml\n"
-            f"  concore run workflow.graphml",
+            f"  concore build workflow.graphml",
             title="Success",
             border_style="green",
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,15 +88,16 @@ class TestConcoreCLI(unittest.TestCase):
         result = self.runner.invoke(cli, ["status"])
         self.assertEqual(result.exit_code, 0)
 
-    def test_run_command_missing_source(self):
+    def test_build_command_missing_source(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             result = self.runner.invoke(
-                cli, ["run", "test-project/workflow.graphml", "--source", "nonexistent"]
+                cli,
+                ["build", "test-project/workflow.graphml", "--source", "nonexistent"],
             )
             self.assertNotEqual(result.exit_code, 0)
 
-    def test_run_command_from_project_dir(self):
+    def test_build_command_from_project_dir(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             self.assertEqual(result.exit_code, 0)
@@ -104,7 +105,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",
@@ -119,12 +120,12 @@ class TestConcoreCLI(unittest.TestCase):
             self.assertTrue(Path("out/STUDY.json").exists())
 
             metadata = json.loads(Path("out/STUDY.json").read_text())
-            self.assertEqual(metadata["generated_by"], "concore run")
+            self.assertEqual(metadata["generated_by"], "concore build")
             self.assertEqual(metadata["study_name"], "out")
             self.assertEqual(metadata["schema_version"], 1)
             self.assertIn("workflow.graphml", metadata["checksums"])
 
-    def test_run_command_default_type(self):
+    def test_build_command_default_type(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             self.assertEqual(result.exit_code, 0)
@@ -132,7 +133,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",
@@ -146,7 +147,7 @@ class TestConcoreCLI(unittest.TestCase):
             else:
                 self.assertTrue(Path("out/build").exists())
 
-    def test_run_command_nested_output_path(self):
+    def test_build_command_nested_output_path(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             self.assertEqual(result.exit_code, 0)
@@ -154,7 +155,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",
@@ -167,7 +168,7 @@ class TestConcoreCLI(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertTrue(Path("build/out/src/concore.py").exists())
 
-    def test_run_command_subdir_source(self):
+    def test_build_command_subdir_source(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             self.assertEqual(result.exit_code, 0)
@@ -184,7 +185,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",
@@ -197,7 +198,7 @@ class TestConcoreCLI(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertTrue(Path("out/src/subdir/script.py").exists())
 
-    def test_run_command_docker_subdir_source_build_paths(self):
+    def test_build_command_docker_subdir_source_build_paths(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             self.assertEqual(result.exit_code, 0)
@@ -214,7 +215,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",
@@ -233,7 +234,7 @@ class TestConcoreCLI(unittest.TestCase):
             self.assertIn("cp ../src/subdir/script.iport concore.iport", build_script)
             self.assertIn("cd ..", build_script)
 
-    def test_run_command_compose_requires_docker_type(self):
+    def test_build_command_compose_requires_docker_type(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             self.assertEqual(result.exit_code, 0)
@@ -241,7 +242,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",
@@ -257,7 +258,7 @@ class TestConcoreCLI(unittest.TestCase):
                 "--compose can only be used with --type docker", result.output
             )
 
-    def test_run_command_docker_compose_single_node(self):
+    def test_build_command_docker_compose_single_node(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             self.assertEqual(result.exit_code, 0)
@@ -265,7 +266,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",
@@ -288,7 +289,7 @@ class TestConcoreCLI(unittest.TestCase):
             metadata = json.loads(Path("out/STUDY.json").read_text())
             self.assertIn("docker-compose.yml", metadata["checksums"])
 
-    def test_run_command_docker_compose_multi_node(self):
+    def test_build_command_docker_compose_multi_node(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             Path("src").mkdir()
             Path("src/common.py").write_text(
@@ -313,7 +314,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "workflow.graphml",
                     "--source",
                     "src",
@@ -332,7 +333,7 @@ class TestConcoreCLI(unittest.TestCase):
             self.assertIn("container_name: 'C'", compose_content)
             self.assertIn("image: 'docker-common'", compose_content)
 
-    def test_run_command_shared_source_specialization_merges_edge_params(self):
+    def test_build_command_shared_source_specialization_merges_edge_params(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             Path("src").mkdir()
             Path("src/common.py").write_text(
@@ -357,7 +358,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "workflow.graphml",
                     "--source",
                     "src",
@@ -377,7 +378,7 @@ class TestConcoreCLI(unittest.TestCase):
             self.assertIn("PORT_NAME_B_C", content)
             self.assertIn("PORT_B_C", content)
 
-    def test_run_command_existing_output(self):
+    def test_build_command_existing_output(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             result = self.runner.invoke(cli, ["init", "test-project"])
             Path("output").mkdir()
@@ -385,7 +386,7 @@ class TestConcoreCLI(unittest.TestCase):
             result = self.runner.invoke(
                 cli,
                 [
-                    "run",
+                    "build",
                     "test-project/workflow.graphml",
                     "--source",
                     "test-project/src",


### PR DESCRIPTION
concore run compiled workflows into scripts but never executed them. Calling this 'run' would seem very un-intuitive from the perspective of Developers and End-Users both.


I have renamed it to concore build.
Made sure to preserve all the functionality of previously 'concore run' and put it to 'concore build'

 We should reserve 'run' for an execution command.

Feature Parity:
Every single flag is preserved: --source, --output, --type, --auto-build, --compose. Only the command name changes.