### PR TITLE
ci: add java phase-2 conformance coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,29 @@ jobs:
             --ignore=ratc/ \
             --ignore=linktest/
 
+  java-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Download jeromq
+        run: |
+          curl -fsSL -o jeromq.jar https://repo1.maven.org/maven2/org/zeromq/jeromq/0.6.0/jeromq-0.6.0.jar
+
+      - name: Compile Java tests
+        run: |
+          javac -cp jeromq.jar concoredocker.java TestLiteralEval.java TestConcoredockerApi.java
+
+      - name: Run Java tests
+        run: |
+          java -cp .:jeromq.jar TestLiteralEval
+          java -cp .:jeromq.jar TestConcoredockerApi
+
   docker-build:
     runs-on: ubuntu-latest
     steps:

--- a/tests/protocol_fixtures/PROTOCOL_FIXTURES.md
+++ b/tests/protocol_fixtures/PROTOCOL_FIXTURES.md
@@ -16,4 +16,12 @@ Phase-2 scope (mapping only):
 
 - No runtime behavior changes.
 - Adds a cross-runtime matrix to track per-case audit status and classification.
-- Keeps CI non-blocking for non-Python runtimes by marking them as `not_audited` until adapters are added.
+- Java runtime entries are tracked with observed status from the Java regression suite (`TestLiteralEval.java`, `TestConcoredockerApi.java`).
+- Current baseline records Java as `observed_pass` for the listed phase-2 cases.
+- Keeps CI non-blocking for non-Python runtimes that are not yet audited by marking them as `not_audited`.
+
+Java conformance execution in CI:
+
+- The `java-test` job in `.github/workflows/ci.yml` downloads `jeromq` for classpath compatibility.
+- It compiles `concoredocker.java`, `TestLiteralEval.java`, and `TestConcoredockerApi.java`.
+- It runs both Java test classes and records initial phase-2 matrix status as observed in CI.

--- a/tests/protocol_fixtures/cross_runtime_matrix.phase2.json
+++ b/tests/protocol_fixtures/cross_runtime_matrix.phase2.json
@@ -6,6 +6,7 @@
   "runtimes": [
     "python",
     "cpp",
+    "java",
     "matlab",
     "octave",
     "verilog"
@@ -34,6 +35,11 @@
           "status": "not_audited",
           "classification": "required",
           "note": "Audit planned in phase 2."
+        },
+        "java": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Validated by TestLiteralEval.java and TestConcoredockerApi.java."
         },
         "matlab": {
           "status": "not_audited",
@@ -66,6 +72,11 @@
           "classification": "required",
           "note": "Audit planned in phase 2."
         },
+        "java": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Validated by TestLiteralEval.java and TestConcoredockerApi.java."
+        },
         "matlab": {
           "status": "not_audited",
           "classification": "required",
@@ -96,6 +107,11 @@
           "status": "not_audited",
           "classification": "required",
           "note": "Audit planned in phase 2."
+        },
+        "java": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Validated by TestLiteralEval.java and TestConcoredockerApi.java."
         },
         "matlab": {
           "status": "not_audited",
@@ -128,6 +144,11 @@
           "classification": "required",
           "note": "Audit planned in phase 2."
         },
+        "java": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Validated by TestLiteralEval.java and TestConcoredockerApi.java."
+        },
         "matlab": {
           "status": "not_audited",
           "classification": "required",
@@ -159,6 +180,11 @@
           "classification": "required",
           "note": "Audit planned in phase 2."
         },
+        "java": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Validated by TestLiteralEval.java and TestConcoredockerApi.java."
+        },
         "matlab": {
           "status": "not_audited",
           "classification": "required",
@@ -189,6 +215,11 @@
           "status": "not_audited",
           "classification": "required",
           "note": "Audit planned in phase 2."
+        },
+        "java": {
+          "status": "observed_pass",
+          "classification": "required",
+          "note": "Validated by TestLiteralEval.java and TestConcoredockerApi.java."
         },
         "matlab": {
           "status": "not_audited",

--- a/tests/test_protocol_conformance_phase2.py
+++ b/tests/test_protocol_conformance_phase2.py
@@ -6,7 +6,7 @@ FIXTURE_DIR = Path(__file__).parent / "protocol_fixtures"
 PHASE1_CASES_PATH = FIXTURE_DIR / "python_phase1_cases.json"
 PHASE2_MATRIX_PATH = FIXTURE_DIR / "cross_runtime_matrix.phase2.json"
 
-EXPECTED_RUNTIMES = {"python", "cpp", "matlab", "octave", "verilog"}
+EXPECTED_RUNTIMES = {"python", "cpp", "java", "matlab", "octave", "verilog"}
 EXPECTED_CLASSIFICATIONS = {"required", "implementation_defined", "known_deviation"}
 EXPECTED_STATUSES = {"observed_pass", "observed_fail", "not_audited"}
 
@@ -30,6 +30,8 @@ def test_phase2_matrix_metadata_and_enums():
     assert doc["phase"] == "2"
     assert doc["mode"] == "report_only"
     assert doc["source_fixture"] == "python_phase1_cases.json"
+    assert "java" in doc["runtimes"]
+    assert len(doc["runtimes"]) == len(set(doc["runtimes"]))
     assert set(doc["runtimes"]) == EXPECTED_RUNTIMES
     assert set(doc["classifications"]) == EXPECTED_CLASSIFICATIONS
     assert set(doc["statuses"]) == EXPECTED_STATUSES
@@ -55,3 +57,12 @@ def test_phase2_matrix_rows_have_consistent_shape():
             assert isinstance(result["note"], str) and result["note"].strip()
             if runtime == "python":
                 assert result["status"] == "observed_pass"
+
+
+def test_phase2_matrix_java_status_is_recorded_for_each_case():
+    for row in _phase2_matrix()["cases"]:
+        java_result = row["runtime_results"]["java"]
+        assert java_result["status"] in EXPECTED_STATUSES
+        assert java_result["classification"] in EXPECTED_CLASSIFICATIONS
+        assert isinstance(java_result["note"], str) and java_result["note"].strip()
+        assert java_result["status"] == "observed_pass"


### PR DESCRIPTION
Adds Java to phase-2 protocol conformance and wires existing Java regression tests into CI.

Changes:

- Added [java](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the phase-2 runtime set in [test_protocol_conformance_phase2.py](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- Updated phase-2 matrix to include Java results for all existing cases in [cross_runtime_matrix.phase2.json](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- Added a [java-test](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) CI job to compile and run [TestLiteralEval](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [TestConcoredockerApi](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [ci.yml](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- Documented Java phase-2 tracking/execution in [PROTOCOL_FIXTURES.md](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Scope: Conformance + CI only (no runtime changes).

Varified:
1. pytest [test_protocol_conformance_phase2.py](http://_vscodecontentref_/8) -q -o addopts='' passed.
2. Java tests passed locally:
[TestLiteralEval](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[TestConcoredockerApi](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

closes #520