### PR TITLE
Docs: Add CONFIG.md documenting config files, env vars, and precedence

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,6 +1,6 @@
 # concore Configuration Reference
 
-This document describes the configuration files used by `mkconcore.py` to locate compilers, runtimes, and Docker settings. All config files are read from `CONCOREPATH` — the directory containing `concore.py`.
+This document describes the configuration files used by `mkconcore.py` to locate compilers, runtimes, and Docker settings. All config files are read from `CONCOREPATH` — the resolved concore install directory (usually the directory containing `concore.py`).
 
 ## How CONCOREPATH Is Resolved
 
@@ -173,7 +173,7 @@ When `mkconcore.py` resolves a tool path, the following precedence applies (high
 
 1. **`concore.tools` file** — overrides everything for compiler/runtime paths
 2. **`concore.sudo` file** — overrides `DOCKEREXE` for Docker executable
-3. **`concore.repo` file** — overrides `DOCKEREPO` for Docker repository
+3. **`concore.repo` file** — overrides the hardcoded default Docker repository prefix (for example, `markgarnold`)
 4. **Environment variables** (`CONCORE_*`, `DOCKEREXE`) — initial defaults
 5. **Hardcoded defaults** — `g++`, `python3`, `iverilog`, `octave`, `docker`, etc.
 


### PR DESCRIPTION
Closes #503

Adds `docs/CONFIG.md` a single reference document for concore's configuration system. **No code changes.**

**What's Documented**
- **`concore.tools`** all 14 supported keys (CPPEXE, PYTHONEXE, VEXE, etc.) with format, platform variants, and examples
- **`concore.octave`** presence-based flag to treat `.m` files as Octave
- **`concore.mcr`**  MATLAB Compiler Runtime path
- **`concore.sudo`** Docker executable override (sudo docker, podman, etc.)
- **`concore.repo`**  Docker Hub repository prefix override
- **Environment variables**  all 15 `CONCORE_*` and `DOCKEREXE` variables with defaults
- **Precedence order**  concore.tools > concore.sudo > env vars > hardcoded defaults
- **Quick start examples**  minimal, typical, Windows, Docker, and Octave setups

**Why**
Per mentor feedback on #503: "If your goal is to simply document these four files somewhere handy, go for it." This is purely additive documentation no code, no config format changes, no modifications to `mkconcore.py`.

**Verified**
- All 170 tests pass (`pytest tests/ -v`)
- `ruff format --check` clean
- All information sourced directly from `mkconcore.py`