### PR TITLE
fix(mkconcore): handle tool executable paths with spaces in generated scripts

### DIFF
--- a/mkconcore.py
+++ b/mkconcore.py
@@ -112,6 +112,20 @@ def safe_relpath(value, context):
         raise ValueError(f"Unsafe {context}: invalid path segment.")
     return normalized
 
+def _quote_executable_windows(value):
+    value = value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        return value
+    return f'"{value}"'
+
+def _quote_executable_posix(value):
+    value = value.strip()
+    if (value.startswith("'") and value.endswith("'")) or (
+        value.startswith('"') and value.endswith('"')
+    ):
+        return value
+    return shlex.quote(value)
+
 MKCONCORE_VER = "22-09-18"
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -1140,6 +1154,24 @@ for node in nodes_dict:
 if concoretype=="posix":
     fdebug.write('#!/bin/bash' + "\n")
     frun.write('#!/bin/bash' + "\n")
+
+# Normalize tool executable quoting once, then reuse existing script templates.
+if concoretype == "windows":
+    PYTHONWIN = _quote_executable_windows(PYTHONWIN)
+    CPPWIN = _quote_executable_windows(CPPWIN)
+    VWIN = _quote_executable_windows(VWIN)
+    JAVACWIN = _quote_executable_windows(JAVACWIN)
+    JAVAWIN = _quote_executable_windows(JAVAWIN)
+    OCTAVEWIN = _quote_executable_windows(OCTAVEWIN)
+    MATLABWIN = _quote_executable_windows(MATLABWIN)
+else:
+    PYTHONEXE = _quote_executable_posix(PYTHONEXE)
+    CPPEXE = _quote_executable_posix(CPPEXE)
+    VEXE = _quote_executable_posix(VEXE)
+    JAVACEXE = _quote_executable_posix(JAVACEXE)
+    JAVAEXE = _quote_executable_posix(JAVAEXE)
+    OCTAVEEXE = _quote_executable_posix(OCTAVEEXE)
+    MATLABEXE = _quote_executable_posix(MATLABEXE)
 
 
 i=0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import shutil
 import os
 import json
 from pathlib import Path
+from unittest.mock import patch
 from click.testing import CliRunner
 from concore_cli.cli import cli
 
@@ -184,6 +185,65 @@ class TestConcoreCLI(unittest.TestCase):
                 self.assertTrue(Path("out/build.bat").exists())
             else:
                 self.assertTrue(Path("out/build").exists())
+
+    def test_build_command_quotes_posix_tool_path_with_spaces(self):
+        with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
+            result = self.runner.invoke(cli, ["init", "test-project"])
+            self.assertEqual(result.exit_code, 0)
+
+            with patch.dict(
+                os.environ,
+                {"CONCORE_PYTHONEXE": "/opt/custom tools/python3"},
+                clear=False,
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "build",
+                        "test-project/workflow.graphml",
+                        "--source",
+                        "test-project/src",
+                        "--output",
+                        "out",
+                        "--type",
+                        "posix",
+                    ],
+                )
+
+            self.assertEqual(result.exit_code, 0)
+            run_script = Path("out/run").read_text()
+            self.assertIn("'/opt/custom tools/python3' script.py", run_script)
+
+    def test_build_command_quotes_windows_tool_path_with_spaces(self):
+        with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
+            result = self.runner.invoke(cli, ["init", "test-project"])
+            self.assertEqual(result.exit_code, 0)
+
+            with patch.dict(
+                os.environ,
+                {"CONCORE_PYTHONWIN": r"C:\Program Files\Python313\python.exe"},
+                clear=False,
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "build",
+                        "test-project/workflow.graphml",
+                        "--source",
+                        "test-project/src",
+                        "--output",
+                        "out",
+                        "--type",
+                        "windows",
+                    ],
+                )
+
+            self.assertEqual(result.exit_code, 0)
+            run_script = Path("out/run.bat").read_text()
+            self.assertIn(
+                '"C:\\Program Files\\Python313\\python.exe" "script.py"',
+                run_script,
+            )
 
     def test_build_command_nested_output_path(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):


### PR DESCRIPTION
This PR fixes a path handling issue in mkconcore where generated run scripts could break if a tool executable path contains spaces (for example, under Program Files).

### **What changed**

- Added safe quoting for tool executable paths during script generation (Windows + POSIX).
- Kept the fix localized to mkconcore.py.
- Added focused CLI tests for both Windows and POSIX spaced-path cases.

It makes generated workflows more reliable across real user setups where tool paths commonly include spaces.