### PR TITLE
Add Julia test matrix to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,34 @@ jobs:
             --ignore=ratc/ \
             --ignore=linktest/
 
+  julia-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        julia-version: ['1.10', '1']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci.txt
+
+      - name: Run Julia tests
+        run: julia --color=yes tests/julia/runtests.jl
+        shell: bash
+
   java-test:
     runs-on: ubuntu-latest
     steps:

--- a/tests/julia/test_interop.jl
+++ b/tests/julia/test_interop.jl
@@ -101,6 +101,8 @@ assert concore.simtime == 7.0, concore.simtime
     end
 
     function cxx_compiler()
+        Sys.iswindows() && return nothing
+
         for name in ("g++", "clang++")
             compiler = Sys.which(name)
             compiler !== nothing && return compiler


### PR DESCRIPTION
The repo now has a Julia test entry point at `tests/julia/runtests.jl`, but CI does not run it yet.

Add a GitHub Actions job that runs the Julia tests on Ubuntu and Windows with Julia 1.10 and the latest stable Julia.