### PR TITLE
ci: fix SHM checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,4 +138,4 @@ jobs:
         # file, so we don't need system SHM semaphores or shared-memory
         # segments to succeed. This catches header-level regressions on
         # the SHM transport (issue #195) without needing g++ at runtime.
-        run: g++ -std=c++17 -Wall -Wextra -fsyntax-only tests/test_shm_cpp_smoke.cpp
+        run: g++ -std=c++17 -Wall -Wextra -I. -fsyntax-only tests/test_shm_cpp_smoke.cpp

--- a/tests/test_shm_concurrency.py
+++ b/tests/test_shm_concurrency.py
@@ -79,39 +79,34 @@ def _writer_unsafe(shm_name: str, lock_path: str, iterations: int) -> int:
 
 
 def _reader_verify(
-    shm_name: str, lock_path: str, iterations: int
+    shm_name: str, lock_path: str, seconds: float
 ) -> tuple[int, int, int]:
     shm = shared_memory.SharedMemory(name=shm_name)
     accepted = 0
     torn = 0
-    missing = 0
     last_seq = 0
     # Writers in this test always pad payloads with a known 200-byte
     # suffix. A torn read produces a payload that does not end in the
     # suffix (because the writer's memcpy was caught mid-byte).
     valid_suffixes = ("X" * 200, "Y" * 200, "Z" * 50)
-    for _ in range(iterations):
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline:
-            snap1 = bytes(shm.buf[: SHM_HEADER_SIZE + SHM_PAYLOAD_SIZE + 1])
-            snap2 = bytes(shm.buf[: SHM_HEADER_SIZE + SHM_PAYLOAD_SIZE + 1])
-            if snap1 != snap2:
-                continue
-            seq, payload = _decode(snap1)
-            if seq == last_seq:
-                continue
-            if seq % 2 != 0:
-                continue
-            if not payload.endswith(valid_suffixes):
-                torn += 1
-                continue
-            accepted += 1
-            last_seq = seq
-            break
-        else:
-            missing += 1
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        snap1 = bytes(shm.buf[: SHM_HEADER_SIZE + SHM_PAYLOAD_SIZE + 1])
+        snap2 = bytes(shm.buf[: SHM_HEADER_SIZE + SHM_PAYLOAD_SIZE + 1])
+        if snap1 != snap2:
+            continue
+        seq, payload = _decode(snap1)
+        if seq == last_seq:
+            continue
+        if seq % 2 != 0:
+            continue
+        if not payload.endswith(valid_suffixes):
+            torn += 1
+            continue
+        accepted += 1
+        last_seq = seq
     shm.close()
-    return accepted, torn, missing
+    return accepted, torn
 
 
 @pytest.fixture
@@ -148,16 +143,12 @@ def test_safe_writer_reader_roundtrip(shm_region):
     ctx = mp.get_context("fork")
     with ctx.Pool(2) as pool:
         writer_async = pool.apply_async(_writer_safe, (name, lock_path, iterations))
-        reader_async = pool.apply_async(
-            _reader_verify, (name, lock_path, iterations * 4)
-        )
+        reader_async = pool.apply_async(_reader_verify, (name, lock_path, 2.0))
         writer_async.get(timeout=30)
-        accepted, torn, missing = reader_async.get(timeout=30)
+        accepted, torn = reader_async.get(timeout=30)
 
     assert torn == 0, f"reader observed {torn} torn reads; SHM is still racy"
-    assert accepted >= iterations, (
-        f"reader accepted only {accepted}/{iterations} payloads"
-    )
+    assert accepted > 0, "reader did not observe any complete payloads"
 
 
 @pytest.mark.skipif(os.name != "posix", reason="fork-based concurrency test")
@@ -167,11 +158,9 @@ def test_unsafe_writer_produces_torn_reads(shm_region):
     ctx = mp.get_context("fork")
     with ctx.Pool(2) as pool:
         writer_async = pool.apply_async(_writer_unsafe, (name, lock_path, iterations))
-        reader_async = pool.apply_async(
-            _reader_verify, (name, lock_path, iterations * 4)
-        )
+        reader_async = pool.apply_async(_reader_verify, (name, lock_path, 2.0))
         writer_async.get(timeout=30)
-        accepted, torn, missing = reader_async.get(timeout=30)
+        accepted, torn = reader_async.get(timeout=30)
 
     if torn == 0:
         pytest.skip("unsafe writer did not produce torn reads on this host")


### PR DESCRIPTION
Fixes two SHM CI issues

- add the repo root include path for the C++ SHM smoke compile
- make the SHM concurrency reader time-bounded instead of waiting for every writer update

The old reader assumption was too strict for polling shared memory and could time out on CI