### PR TITLE
mkconcore: add Julia Docker generation

### DIFF
--- a/Dockerfile.jl
+++ b/Dockerfile.jl
@@ -1,0 +1,4 @@
+FROM julia:1.10
+
+WORKDIR /src
+COPY . .

--- a/mkconcore.py
+++ b/mkconcore.py
@@ -634,6 +634,16 @@ if 'py' in required_langs:
         print(CONCOREPATH+" is not correct path to concore (missing concore_base.py)")
         quit()
 
+if 'jl' in required_langs and concoretype=="docker":
+    try:
+        fsource = open(CONCOREPATH+"/concoredocker.jl")
+    except (FileNotFoundError, IOError):
+        print(CONCOREPATH+" is not correct path to concore (missing concoredocker.jl)")
+        quit()
+    with open(outdir+"/src/concore.jl","w") as fcopy:
+        fcopy.write(fsource.read())
+    fsource.close()
+
 if 'cpp' in required_langs:
     try:
         if concoretype=="docker":
@@ -790,6 +800,9 @@ if (concoretype=="docker"):
                     if langext=="py":
                         src_path = CONCOREPATH+"/Dockerfile.py"
                         logging.info("assuming .py extension for Dockerfile")
+                    elif langext == "jl":
+                        src_path = CONCOREPATH+"/Dockerfile.jl"
+                        logging.info("assuming .jl extension for Dockerfile")
                     elif langext == "cpp":  # 6/22/21
                         src_path = CONCOREPATH+"/Dockerfile.cpp"
                         logging.info("assuming .cpp extension for Dockerfile")
@@ -814,6 +827,8 @@ if (concoretype=="docker"):
                     fcopy.write(source_content)
                     if langext=="py":
                         fcopy.write('CMD ["python", "-i", "'+sourcecode+'"]\n')
+                    if langext=="jl":
+                        fcopy.write('CMD ["julia", "'+sourcecode+'"]\n')
                     if langext=="m":
                         fcopy.write('CMD ["octave", "-qf", "--eval", "run('+"'"+sourcecode+"'"+')"]\n') #3/28/21
                     if langext=="sh":
@@ -837,6 +852,8 @@ if (concoretype=="docker"):
             if langext == "py": #4/29/21
                 fbuild.write("cp ../src/concore.py .\n")
                 fbuild.write("cp ../src/concore_base.py .\n")
+            elif langext == "jl":
+                fbuild.write("cp ../src/concore.jl .\n")
             elif langext == "cpp": #6/22/21
                 fbuild.write("cp ../src/concore.hpp .\n")
             elif langext == "v": #6/25/21

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -391,6 +391,54 @@ class TestConcoreCLI(unittest.TestCase):
             metadata = json.loads(Path("out/STUDY.json").read_text())
             self.assertIn("docker-compose.yml", metadata["checksums"])
 
+    def test_build_command_docker_compose_julia_node(self):
+        with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
+            result = self.runner.invoke(cli, ["init", "test-project"])
+            self.assertEqual(result.exit_code, 0)
+
+            script_path = Path("test-project/src/script.py")
+            script_path.rename("test-project/src/script.jl")
+            Path("test-project/src/script.jl").write_text(
+                'include("concore.jl")\nusing .Concore\n'
+            )
+
+            workflow_path = Path("test-project/workflow.graphml")
+            content = workflow_path.read_text()
+            workflow_path.write_text(content.replace("N1:script.py", "N1:script.jl"))
+
+            result = self.runner.invoke(
+                cli,
+                [
+                    "build",
+                    "test-project/workflow.graphml",
+                    "--source",
+                    "test-project/src",
+                    "--output",
+                    "out",
+                    "--type",
+                    "docker",
+                    "--compose",
+                ],
+            )
+            self.assertEqual(result.exit_code, 0)
+
+            docker_runtime = Path(__file__).resolve().parents[1] / "concoredocker.jl"
+            self.assertEqual(
+                Path("out/src/concore.jl").read_text(), docker_runtime.read_text()
+            )
+
+            dockerfile = Path("out/src/Dockerfile.script").read_text()
+            self.assertIn("FROM julia:1.10", dockerfile)
+            self.assertIn('CMD ["julia", "script.jl"]', dockerfile)
+
+            build_script = Path("out/build").read_text()
+            self.assertIn("cp ../src/script.jl .", build_script)
+            self.assertIn("cp ../src/concore.jl .", build_script)
+
+            compose_content = Path("out/docker-compose.yml").read_text()
+            self.assertIn("container_name: 'N1'", compose_content)
+            self.assertIn("image: 'docker-script'", compose_content)
+
     def test_build_command_docker_compose_multi_node(self):
         with self.runner.isolated_filesystem(temp_dir=self.temp_dir):
             Path("src").mkdir()


### PR DESCRIPTION
Adds first part of week 8 Docker work, support to the existing Docker study generator.

Selects Dockerfile.jl, copies concoredocker.jl into the build context, and generates the Julia command. Includes a CLI test for the generated Docker and Compose files.

The mixed Python–Julia container study will follow separately.