### PR TITLE
benchmarks: add Julia backend comparisons

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,37 @@
+# Concore benchmarks
+
+The benchmark scripts compare Julia's File, Mmap, and ZMQ backends and run
+matched Julia and Python workloads.
+
+Run the full benchmarks from the repository root:
+
+```sh
+julia --startup-file=no benchmark/bench_julia.jl
+python benchmark/bench_python.py
+```
+
+Use `--quick` for a smoke run:
+
+```sh
+julia --startup-file=no benchmark/bench_julia.jl --quick
+python benchmark/bench_python.py --quick
+```
+
+The scripts use the wire value `[0.0, 1.0, 2.0, 3.0, 4.0]`. The parse and
+format workloads use the current language runtime behavior. A round trip
+writes a request, reads it, writes a reply, and reads the reply through the
+current Concore API.
+
+The normal run uses 5,000 iterations, 100 warmup operations, and five measured
+repetitions. Quick mode uses 100 iterations, 10 warmup operations, and three
+measured repetitions. Setup and warmup are outside the timed sections. Output
+reports the median batch time and the rate calculated from that median.
+
+File and Mmap use a temporary directory. ZMQ uses a local REQ/REP socket pair
+and is skipped when ZMQ.jl is unavailable. The Julia/Python comparison covers
+the matched parse, format, and File round-trip workloads.
+
+Results depend on the host, filesystem cache, and runtime versions. The ZMQ
+measurement uses two sockets in one process and does not include network or
+process scheduling overhead. These scripts are not intended as CI performance
+thresholds.

--- a/benchmark/bench_julia.jl
+++ b/benchmark/bench_julia.jl
@@ -1,0 +1,131 @@
+include(joinpath(@__DIR__, "..", "concore.jl"))
+using .Concore
+using Printf
+using Sockets
+using Statistics
+
+const QUICK = "--quick" in ARGS
+const ITERATIONS = QUICK ? 100 : 5_000
+const WARMUP = QUICK ? 10 : 100
+const REPEATS = QUICK ? 3 : 5
+const PAYLOAD = [1.0, 2.0, 3.0, 4.0]
+const WIRE = "[0.0, 1.0, 2.0, 3.0, 4.0]"
+const INITIAL = "[0.0, 0.0, 0.0, 0.0, 0.0]"
+
+function measure(label, unit, f, expected)
+    result = nothing
+    for _ in 1:WARMUP
+        result = f()
+    end
+    result == expected || error("$label warmup returned an unexpected value")
+
+    elapsed = Vector{Float64}(undef, REPEATS)
+    for repeat in 1:REPEATS
+        start = time_ns()
+        for _ in 1:ITERATIONS
+            result = f()
+        end
+        elapsed[repeat] = (time_ns() - start) / 1e9
+        result == expected || error("$label returned an unexpected value")
+    end
+
+    seconds = median(elapsed)
+    rate = ITERATIONS / seconds
+    @printf("%-24s %12.3f %18.0f %s/s\n", label, seconds * 1e3, rate, unit)
+end
+
+function reset_state!()
+    Concore.simtime = 0.0
+    Concore.delay = 0.0
+    Concore.s = ""
+    Concore.olds = ""
+    Concore.retrycount = 0
+end
+
+function file_roundtrip()
+    Concore.concore_write(1, "request", PAYLOAD)
+    request = Concore.concore_read(1, "request", INITIAL)
+    Concore.concore_write(1, "reply", request)
+    reply = Concore.concore_read(1, "reply", INITIAL)
+    Concore.s = ""
+    Concore.olds = ""
+    return reply
+end
+
+function benchmark_file_backend(label, backend)
+    dir = mktempdir(; cleanup=false)
+    old_backend = Concore._backend
+    old_inpath = Concore.inpath
+    old_outpath = Concore.outpath
+    old_delay = Concore.delay
+    try
+        path = joinpath(dir, "io")
+        mkpath(path * "1")
+        Concore.inpath = path
+        Concore.outpath = path
+        Concore.concore_init!(backend)
+        reset_state!()
+        measure(label, "round trips", file_roundtrip, PAYLOAD)
+    finally
+        Concore.mmap_cleanup()
+        Concore._backend = old_backend
+        Concore.inpath = old_inpath
+        Concore.outpath = old_outpath
+        reset_state!()
+        Concore.delay = old_delay
+        GC.gc()
+        rm(dir; recursive=true, force=true)
+    end
+end
+
+function benchmark_zmq()
+    if !Concore.HAS_ZMQ
+        println("ZMQ round trip           skipped (ZMQ.jl is not installed)")
+        return
+    end
+
+    server = Sockets.listen(Sockets.localhost, 0)
+    port = Sockets.getsockname(server)[2]
+    close(server)
+    address = "tcp://127.0.0.1:$port"
+    old_backend = Concore._backend
+    old_delay = Concore.delay
+
+    try
+        Concore.concore_init!(Concore.ZmqBackend())
+        reset_state!()
+        Concore.init_zmq_port("rep", "bind", address, "REP")
+        Concore.init_zmq_port("req", "connect", address, "REQ")
+        sleep(0.1)
+
+        function zmq_roundtrip()
+            Concore.concore_write("req", "request", PAYLOAD)
+            request = Concore.concore_read("rep", "request", INITIAL)
+            Concore.concore_write("rep", "reply", request)
+            reply = Concore.concore_read("req", "reply", INITIAL)
+            return reply
+        end
+
+        measure("ZMQ round trip", "round trips", zmq_roundtrip, PAYLOAD)
+    finally
+        Concore.terminate_zmq()
+        Concore._backend = old_backend
+        reset_state!()
+        Concore.delay = old_delay
+    end
+end
+
+unexpected = filter(arg -> arg != "--quick", ARGS)
+isempty(unexpected) || error("unknown argument: $(first(unexpected))")
+
+println("Julia $(VERSION) | $(Sys.KERNEL) $(Sys.MACHINE)")
+println("iterations=$ITERATIONS warmup=$WARMUP repeats=$REPEATS")
+println()
+@printf("%-24s %12s %18s\n", "workload", "median ms", "rate")
+println("-" ^ 58)
+
+measure("Parse wire", "operations", () -> Concore.safe_parse_list(WIRE), [0.0; PAYLOAD])
+measure("Format wire", "operations", () -> Concore._format_wire([0.0; PAYLOAD]), WIRE)
+benchmark_file_backend("File round trip", Concore.FileBackend())
+benchmark_file_backend("Mmap round trip", Concore.MmapBackend())
+benchmark_zmq()

--- a/benchmark/bench_python.py
+++ b/benchmark/bench_python.py
@@ -1,0 +1,117 @@
+import argparse
+import os
+import platform
+import statistics
+import sys
+import tempfile
+import time
+from ast import literal_eval
+from pathlib import Path
+
+
+PAYLOAD = [1.0, 2.0, 3.0, 4.0]
+WIRE = "[0.0, 1.0, 2.0, 3.0, 4.0]"
+INITIAL = "[0.0, 0.0, 0.0, 0.0, 0.0]"
+
+
+def measure(label, unit, function, expected, iterations, warmup, repeats):
+    result = None
+    for _ in range(warmup):
+        result = function()
+    if result != expected:
+        raise RuntimeError(f"{label} warmup returned an unexpected value")
+
+    elapsed = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        for _ in range(iterations):
+            result = function()
+        elapsed.append(time.perf_counter() - start)
+        if result != expected:
+            raise RuntimeError(f"{label} returned an unexpected value")
+
+    seconds = statistics.median(elapsed)
+    rate = iterations / seconds
+    print(f"{label:<24} {seconds * 1e3:>12.3f} {rate:>18.0f} {unit}/s")
+
+
+def load_concore(workdir):
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(workdir)
+        import concore
+    finally:
+        os.chdir(old_cwd)
+    return concore
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quick", action="store_true")
+    args = parser.parse_args()
+
+    iterations = 100 if args.quick else 5_000
+    warmup = 10 if args.quick else 100
+    repeats = 3 if args.quick else 5
+
+    print(
+        f"Python {platform.python_version()} | {platform.system()} {platform.machine()}"
+    )
+    print(f"iterations={iterations} warmup={warmup} repeats={repeats}")
+    print()
+    print(f"{'workload':<24} {'median ms':>12} {'rate':>18}")
+    print("-" * 58)
+
+    measure(
+        "Parse wire",
+        "operations",
+        lambda: literal_eval(WIRE),
+        [0.0] + PAYLOAD,
+        iterations,
+        warmup,
+        repeats,
+    )
+    measure(
+        "Format wire",
+        "operations",
+        lambda: str([0.0] + PAYLOAD),
+        WIRE,
+        iterations,
+        warmup,
+        repeats,
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        concore = load_concore(tempdir)
+        path = os.path.join(tempdir, "io")
+        os.makedirs(path + "1")
+        concore.inpath = path
+        concore.outpath = path
+        concore.delay = 0
+        concore.simtime = 0
+
+        def file_roundtrip():
+            concore.write(1, "request", PAYLOAD)
+            request = concore.read(1, "request", INITIAL)
+            concore.write(1, "reply", request)
+            reply = concore.read(1, "reply", INITIAL)
+            concore.s = ""
+            concore.olds = ""
+            return reply
+
+        measure(
+            "File round trip",
+            "round trips",
+            file_roundtrip,
+            PAYLOAD,
+            iterations,
+            warmup,
+            repeats,
+        )
+        concore.terminate_zmq()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds week 9 part 1 benchmarks for File, Mmap, and ZMQ backends, with matched Julia and Python workloads.
Includes quick runs and basic methodology. Results will follow separately after this.